### PR TITLE
Switch to Globus Auth authentication

### DIFF
--- a/qiita_core/configuration_manager.py
+++ b/qiita_core/configuration_manager.py
@@ -230,11 +230,15 @@ class ConfigurationManager(object):
         if not self.key_file:
             self.key_file = join(install_dir, 'qiita_core', 'support_files',
                                  'server.key')
+
     def _get_oauth2(self, config):
         """Get the configuration of the oauth2 section"""
-        self.globus_client_key = config.get('oauth2', 'GLOBUS_OAUTH2_CLIENT_KEY')
-        self.globus_client_secret = config.get('oauth2', 'GLOBUS_OAUTH2_CLIENT_SECRET')
-        self.globus_redirect_uri = config.get('oauth2', 'GLOBUS_OAUTH2_REDIRECT_URI')
+        self.globus_client_key = config.get('oauth2',
+                                            'GLOBUS_OAUTH2_CLIENT_KEY')
+        self.globus_client_secret = config.get('oauth2',
+                                               'GLOBUS_OAUTH2_CLIENT_SECRET')
+        self.globus_redirect_uri = config.get('oauth2',
+                                              'GLOBUS_OAUTH2_REDIRECT_URI')
         self.globus_scope = config.get('oauth2', 'GLOBUS_OAUTH2_SCOPE')
 
     def _get_torque(self, config):

--- a/qiita_core/configuration_manager.py
+++ b/qiita_core/configuration_manager.py
@@ -146,6 +146,7 @@ class ConfigurationManager(object):
             raise MissingConfigSection(', '.join(missing))
 
         self._get_main(config)
+        self._get_oauth2(config)
         self._get_smtp(config)
         self._get_torque(config)
         self._get_postgres(config)
@@ -229,6 +230,12 @@ class ConfigurationManager(object):
         if not self.key_file:
             self.key_file = join(install_dir, 'qiita_core', 'support_files',
                                  'server.key')
+    def _get_oauth2(self, config):
+        """Get the configuration of the oauth2 section"""
+        self.globus_client_key = config.get('oauth2', 'GLOBUS_OAUTH2_CLIENT_KEY')
+        self.globus_client_secret = config.get('oauth2', 'GLOBUS_OAUTH2_CLIENT_SECRET')
+        self.globus_redirect_uri = config.get('oauth2', 'GLOBUS_OAUTH2_REDIRECT_URI')
+        self.globus_scope = config.get('oauth2', 'GLOBUS_OAUTH2_SCOPE')
 
     def _get_torque(self, config):
         """Get the configuration of the torque section"""

--- a/qiita_core/support_files/config_test.cfg
+++ b/qiita_core/support_files/config_test.cfg
@@ -65,6 +65,19 @@ KEY_FILE =
 #   print b64encode(uuid4().bytes + uuid4().bytes)"
 COOKIE_SECRET = SECRET
 
+# ----------------------------- OAuth2 settings ---------------------------
+[oauth2]
+# Globus Auth OAuth2 client id and secret obtained from https://developers.globus.org (Register your app with Globus)
+GLOBUS_OAUTH2_CLIENT_KEY = 
+GLOBUS_OAUTH2_CLIENT_SECRET = 
+
+# Redirect URI, Globus Auth will redirect a web browser back to after a successfully loggin in to Globus Auth
+# <example.com> has to be replaced with your Qiita server hostname.
+GLOBUS_OAUTH2_REDIRECT_URI = https://<example.com>/auth/globus/
+
+# Scopes that access/refresh tokens are requested from Globus Auth for
+GLOBUS_OAUTH2_SCOPE = "openid profile email urn:globus:auth:scope:transfer.api.globus.org:all"
+
 # ----------------------------- SMTP settings -----------------------------
 [smtp]
 # The hostname to connect to

--- a/qiita_pet/handlers/auth_handlers.py
+++ b/qiita_pet/handlers/auth_handlers.py
@@ -6,6 +6,7 @@
 # The full license is in the file LICENSE, distributed with this software.
 # -----------------------------------------------------------------------------
 
+import secrets
 from tornado.escape import url_escape, json_encode
 
 from qiita_pet.handlers.base_handlers import BaseHandler
@@ -214,12 +215,10 @@ class GlobusOAuth2LoginHandler(BaseHandler, GlobusOAuth2Mixin):
 
             # Check if the user exists. If it does not, create the user
             username = user_info.get("preferred_username")
-            password = 'RviwFvie83!#'
+            password = secrets.token_urlsafe(16)
             info = {
-                # "sub": user_info.get("sub"),
                 "name": user_info.get("name"),
                 "affiliation": user_info.get("organization")
-                # "email": user_info.get("email")
             }
             try:
                 User.create(username, password, info)

--- a/qiita_pet/handlers/auth_handlers.py
+++ b/qiita_pet/handlers/auth_handlers.py
@@ -200,10 +200,7 @@ class GlobusOAuth2LoginHandler(BaseHandler, GlobusOAuth2Mixin):
         if self.get_argument("code", False):
             nextpage = self.get_argument("next", None)
             if nextpage is None:
-                if "auth/" not in self.request.headers["Referer"]:
-                    nextpage = self.request.headers["Referer"]
-                else:
-                    nextpage = "%s/" % qiita_config.portal.portal_dir
+                nextpage = "%s/" % qiita_config.portal_dir
             # Exchange the code to access/refresh tokens
             tokens = await self.get_tokens(
                 key=qiita_config.globus_client_key,

--- a/qiita_pet/handlers/auth_handlers.py
+++ b/qiita_pet/handlers/auth_handlers.py
@@ -184,12 +184,17 @@ class GlobusOAuth2LoginHandler(BaseHandler, GlobusOAuth2Mixin):
         self.authorize_redirect(
             redirect_uri=qiita_config.globus_redirect_uri,
             client_id=qiita_config.globus_client_key,
-            scope=["openid", "profile", "email", "urn:globus:auth:scope:transfer.api.globus.org:all"],
+            scope=["openid",
+                   "profile",
+                   "email",
+                   "urn:globus:auth:scope:transfer.api.globus.org:all"],
             response_type="code",
             extra_params={"access_type": "offline"})
 
-    # Process a redirect from Globus Auth, exchange the code to
-    # access/refresh tokens,and get userinfo
+    """
+    Process a redirect from Globus Auth, exchange the code to
+    access/refresh tokens,and get userinfo
+    """
     async def get(self):
         if self.get_argument("code", False):
             nextpage = self.get_argument("next", None)
@@ -217,15 +222,15 @@ class GlobusOAuth2LoginHandler(BaseHandler, GlobusOAuth2Mixin):
                 #"email": user_info.get("email")
             }
             try:
-                created = User.create(username, password, info)
+                User.create(username, password, info)
             except QiitaDBDuplicateError:
                 pass
             # Set current  user
             self.set_current_user(username)
 
             # Update tokens
-            #self.set_secure_cookie("access_token", tokens["access_token"])
-            #self.set_secure_cookie("refresh_token", tokens["refresh_token"])
+            self.set_secure_cookie("access_token", tokens["access_token"])
+            self.set_secure_cookie("refresh_token", tokens["refresh_token"])
 
             self.redirect(nextpage)
 

--- a/qiita_pet/handlers/auth_handlers.py
+++ b/qiita_pet/handlers/auth_handlers.py
@@ -216,10 +216,10 @@ class GlobusOAuth2LoginHandler(BaseHandler, GlobusOAuth2Mixin):
             username = user_info.get("preferred_username")
             password = 'RviwFvie83!#'
             info = {
-                #"sub": user_info.get("sub"),
+                # "sub": user_info.get("sub"),
                 "name": user_info.get("name"),
                 "affiliation": user_info.get("organization")
-                #"email": user_info.get("email")
+                # "email": user_info.get("email")
             }
             try:
                 User.create(username, password, info)

--- a/qiita_pet/handlers/globus.py
+++ b/qiita_pet/handlers/globus.py
@@ -56,7 +56,8 @@ class GlobusOAuth2Mixin(OAuth2Mixin):
         callback = wrap(functools.partial(self._on_oauth2_request, callback))
         http = self.get_auth_http_client()
         if post_args is not None:
-            fut = http.fetch(url, method="POST", headers=headers, body=urllib_parse.urlencode(post_args))
+            fut = http.fetch(url, method="POST", headers=headers,
+                             body=urllib_parse.urlencode(post_args))
         else:
             fut = http.fetch(url, headers=headers)
         fut.add_done_callback(callback)

--- a/qiita_pet/handlers/globus.py
+++ b/qiita_pet/handlers/globus.py
@@ -1,0 +1,61 @@
+import functools
+import urllib.parse as urllib_parse
+from tornado import escape
+from tornado.concurrent import future_set_result_unless_cancelled
+from tornado.stack_context import wrap
+from tornado.auth import OAuth2Mixin
+from tornado.auth import _auth_return_future
+
+
+class GlobusOAuth2Mixin(OAuth2Mixin):
+    _OAUTH_AUTHORIZE_URL = "https://auth.globus.org/v2/oauth2/authorize"
+    _OAUTH_ACCESS_TOKEN_URL = "https://auth.globus.org/v2/oauth2/token"
+    _OAUTH_USERINFO_URL = "https://auth.globus.org/v2/oauth2/userinfo"
+    _OAUTH_SETTINGS_KEY = "globus_oauth"
+
+    @_auth_return_future
+    def get_tokens(self, key, secret, redirect_uri, code, callback):
+        http = self.get_auth_http_client()
+        body = urllib_parse.urlencode({
+            "redirect_uri": redirect_uri,
+            "code": code,
+            "client_id": key,
+            "client_secret": secret,
+            "grant_type": "authorization_code"
+        })
+        fut = http.fetch(self._OAUTH_ACCESS_TOKEN_URL,
+                         method="POST",
+                         headers={"Content-Type": "application/x-www-form-urlencoded"},
+                         body=body)
+        fut.add_done_callback(wrap(functools.partial(self._on_access_token, callback)))
+
+    def _on_access_token(self, future, response_fut):
+        """Callback function for the exchange to the access token."""
+        try:
+            response = response_fut.result()
+        except Exception as e:
+            future.set_exception(AuthError('Globus auth error: %s' % str(e)))
+            return
+
+        args = escape.json_decode(response.body)
+        future_set_result_unless_cancelled(future, args)
+
+    def get_user_info(self, access_token):
+        return self.oauth2_request(self._OAUTH_USERINFO_URL,
+                                   access_token=access_token)
+
+    @_auth_return_future
+    def oauth2_request(self, url, callback, access_token=None,
+                       post_args=None, *args):
+        headers = {}
+        if access_token:
+            headers = {"Authorization": "Bearer " + access_token}
+        if args:
+            url += "?" + urllib_parse.urlencode(args)
+        callback = wrap(functools.partial(self._on_oauth2_request, callback))
+        http = self.get_auth_http_client()
+        if post_args is not None:
+            fut = http.fetch(url, method="POST", headers=headers, body=urllib_parse.urlencode(post_args))
+        else:
+            fut = http.fetch(url, headers=headers)
+        fut.add_done_callback(callback)

--- a/qiita_pet/handlers/globus.py
+++ b/qiita_pet/handlers/globus.py
@@ -3,8 +3,7 @@ import urllib.parse as urllib_parse
 from tornado import escape
 from tornado.concurrent import future_set_result_unless_cancelled
 from tornado.stack_context import wrap
-from tornado.auth import OAuth2Mixin
-from tornado.auth import _auth_return_future
+from tornado.auth import (AuthError, OAuth2Mixin, _auth_return_future)
 
 
 class GlobusOAuth2Mixin(OAuth2Mixin):
@@ -23,11 +22,13 @@ class GlobusOAuth2Mixin(OAuth2Mixin):
             "client_secret": secret,
             "grant_type": "authorization_code"
         })
-        fut = http.fetch(self._OAUTH_ACCESS_TOKEN_URL,
-                         method="POST",
-                         headers={"Content-Type": "application/x-www-form-urlencoded"},
-                         body=body)
-        fut.add_done_callback(wrap(functools.partial(self._on_access_token, callback)))
+        fut = http.fetch(
+            self._OAUTH_ACCESS_TOKEN_URL,
+            method="POST",
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+            body=body)
+        fut.add_done_callback(wrap(functools.partial(self._on_access_token,
+                                                     callback)))
 
     def _on_access_token(self, future, response_fut):
         """Callback function for the exchange to the access token."""

--- a/qiita_pet/templates/sitebase.html
+++ b/qiita_pet/templates/sitebase.html
@@ -439,17 +439,13 @@
                 <a href="{% raw qiita_config.portal_dir %}/auth/forgot/">Forgot Password</a>
               </li>
             </ul>
+            <!--
             <form action="{% raw qiita_config.portal_dir %}/auth/create/" class="navbar-form navbar-right">
               <input type="submit" value="Sign up" class="btn btn-info">
             </form>
-            <form class="navbar-form navbar-right" role="form" action="{% raw qiita_config.portal_dir %}/auth/login/" method="post">
-              <div class="form-group">
-                <input tabindex="1" type="text" id="username" name="username" placeholder="Email" class="form-control">
-              </div>
-              <div class="form-group">
-                <input tabindex="2" type="password" id="password" name="password" placeholder="Password" class="form-control">
-              </div>
-              <button tabindex="3" type="submit" class="btn btn-success">Sign in</button>
+            -->
+            <form class="navbar-form navbar-right" role="form" action="{% raw qiita_config.portal_dir %}/auth/globus/" method="post">
+              <button tabindex="3" type="submit" class="btn btn-success">Sign in with Globus</button>
             </form>
             {% end %}
             <ul class="nav navbar-nav">

--- a/qiita_pet/templates/user_profile.html
+++ b/qiita_pet/templates/user_profile.html
@@ -20,28 +20,7 @@ $( document ).ready(function() { dualpass_validator(); });
       </div>
       {% end %}
       <div style="color:red;">{{msg}}</div>
-      <button type="submit" class="btn btn-success">Save Edits</button>
     </form>
-  </div>
-  <div class="col-lg-6">
-  <h3>Change Password</h3>
-  <form role="form" action="{% raw qiita_config.portal_dir %}/profile/" method="post" id="change_pass" name="change_pass" class="dualpass">
-  <input type="hidden" name="action" value="password">
-<div class="form-group">
-    <label for="oldpass" class="col-sm-10 control-label">Old Password</label>
-      <input type="password" class="form-control" id="oldpass" name="oldpass">
-</div>
-<div class="form-group">
-    <label for="newpass" class="col-sm-10 control-label">New Password</label>
-      <input type="password" class="form-control" id="newpass" name="newpass">
-</div>
-<div class="form-group">
-    <label for="newpass2" class="col-sm-10 control-label">Repeat New Password</label>
-      <input type="password" class="form-control" id="newpass2" name="newpass2">
-  </div>
-<div style="color:red;">{{passmsg}}</div>
-<button class="btn btn-danger">Change Password</button>
-</form>
   </div>
 </div>
 {%end%}

--- a/qiita_pet/webserver.py
+++ b/qiita_pet/webserver.py
@@ -20,7 +20,8 @@ from qiita_core.util import is_test_environment
 from qiita_pet.handlers.base_handlers import (
     MainHandler, NoPageHandler, IFrame)
 from qiita_pet.handlers.auth_handlers import (
-    AuthCreateHandler, AuthLoginHandler, AuthLogoutHandler, AuthVerifyHandler, GlobusOAuth2LoginHandler)
+    AuthCreateHandler, AuthLoginHandler, AuthLogoutHandler, AuthVerifyHandler,
+    GlobusOAuth2LoginHandler)
 from qiita_pet.handlers.user_handlers import (
     ChangeForgotPasswordHandler, ForgotPasswordHandler, UserProfileHandler,
     UserMessagesHander, UserJobs)

--- a/qiita_pet/webserver.py
+++ b/qiita_pet/webserver.py
@@ -20,7 +20,7 @@ from qiita_core.util import is_test_environment
 from qiita_pet.handlers.base_handlers import (
     MainHandler, NoPageHandler, IFrame)
 from qiita_pet.handlers.auth_handlers import (
-    AuthCreateHandler, AuthLoginHandler, AuthLogoutHandler, AuthVerifyHandler)
+    AuthCreateHandler, AuthLoginHandler, AuthLogoutHandler, AuthVerifyHandler, GlobusOAuth2LoginHandler)
 from qiita_pet.handlers.user_handlers import (
     ChangeForgotPasswordHandler, ForgotPasswordHandler, UserProfileHandler,
     UserMessagesHander, UserJobs)
@@ -103,6 +103,7 @@ class Application(tornado.web.Application):
             (r"/auth/verify/(.*)", AuthVerifyHandler),
             (r"/auth/forgot/", ForgotPasswordHandler),
             (r"/auth/reset/(.*)", ChangeForgotPasswordHandler),
+            (r"/auth/globus/", GlobusOAuth2LoginHandler),
             (r"/profile/", UserProfileHandler),
             (r"/user/messages/", UserMessagesHander),
             (r"/user/jobs/", UserJobs),


### PR DESCRIPTION
The pull request replaces local authentication with the Globus Auth IdP. It still uses the same User model which contains username, name, password, affiliation, address, phone but the information is obtained from Globus Auth. Globus Auth provides a sub (OIDC subject which is a unique UUID in this case), preferred_username, name, organization, email. The following Globus information is mapped to the Qiita User fields:
preferred_username -> username,
name -> name,
organization -> affiliation.
The GlobusOAuth2LoginHandler also exchanges an OAuth2 authorization code to access/refresh tokens that can be used to submit file transfers, etc.