### PR TITLE
minor improvements

### DIFF
--- a/qiita_db/metadata_template/base_metadata_template.py
+++ b/qiita_db/metadata_template/base_metadata_template.py
@@ -1182,10 +1182,9 @@ class MetadataTemplate(qdb.base.QiitaObject):
                 sql += ' AND sample_id IN %s'
                 qdb.sql_connection.TRN.add(sql, [tuple(samples)])
 
-            df = pd.DataFrame(qdb.sql_connection.TRN.execute_fetchindex())
-            df = pd.concat([df.drop(1, axis=1),
-                            pd.DataFrame(df[1].tolist(), dtype='str')], axis=1)
-            df.set_index(0, inplace=True)
+            data = qdb.sql_connection.TRN.execute_fetchindex()
+            df = pd.DataFrame([d for _, d in data], index=[i for i, _ in data],
+                              dtype=str)
             df.index.name = 'sample_id'
             df.where((pd.notnull(df)), None)
             id_column_name = 'qiita_%sid' % (self._table_prefix)

--- a/qiita_db/metadata_template/base_metadata_template.py
+++ b/qiita_db/metadata_template/base_metadata_template.py
@@ -1184,7 +1184,7 @@ class MetadataTemplate(qdb.base.QiitaObject):
 
             df = pd.DataFrame(qdb.sql_connection.TRN.execute_fetchindex())
             df = pd.concat([df.drop(1, axis=1),
-                            pd.DataFrame(df[1].tolist())], axis=1)
+                            pd.DataFrame(df[1].tolist(), dtype='str')], axis=1)
             df.set_index(0, inplace=True)
             df.index.name = 'sample_id'
             df.where((pd.notnull(df)), None)

--- a/scripts/qiita-recover-jobs
+++ b/scripts/qiita-recover-jobs
@@ -47,7 +47,7 @@ def _retrieve_queue_jobs():
     # looking for qiita jobs
     # i-1: the line before is the job name, which is the internal qiita job id
     job_names = [lines[i-1] for i, l in enumerate(lines)
-                 if 'Job_Owner = qiita@qiita.ucsd.edu' in l]
+                 if l.startswith('    Job_Owner = qiita')]
 
     qiita_jids = []
     for job in job_names:


### PR DESCRIPTION
Two minor improvements:
1. Improve performance of `_common_to_dataframe_steps` ~17 seconds for AGP:
```
In [50]: %timeit SampleTemplate(10317).to_dataframe()                                                                                                                                                                                                                                       
1min 8s ± 224 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

In [51]: %timeit ST(10317).to_dataframe()                                                                                                                                                                                                                                                   
51.8 s ± 259 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```
2. Turns out that jobs actually append the node where the job was submitted so that list comprehension will miss jobs submitted in the workers.  