### PR TITLE
add Command.processing_jobs

### DIFF
--- a/qiita_db/software.py
+++ b/qiita_db/software.py
@@ -761,6 +761,7 @@ class Command(qdb.base.QiitaObject):
         Returns
         -------
         list of qiita_db.processing_job.ProcessingJob
+            List of jobs that used this command.
         """
 
         with qdb.sql_connection.TRN:

--- a/qiita_db/software.py
+++ b/qiita_db/software.py
@@ -754,6 +754,25 @@ class Command(qdb.base.QiitaObject):
 
         return result[0]
 
+    @property
+    def processing_jobs(self):
+        """All the processing_jobs that used this command
+
+        Returns
+        -------
+        list of qiita_db.processing_job.ProcessingJob
+        """
+
+        with qdb.sql_connection.TRN:
+            sql = """SELECT processing_job_id FROM
+                     qiita.processing_job
+                     WHERE command_id = %s"""
+            qdb.sql_connection.TRN.add(sql, [self.id])
+
+            jids = qdb.sql_connection.TRN.execute_fetchflatten()
+
+        return [qdb.processing_job.ProcessingJob(j) for j in jids]
+
 
 class Software(qdb.base.QiitaObject):
     r"""A software package available in the system

--- a/qiita_db/test/test_software.py
+++ b/qiita_db/test/test_software.py
@@ -464,6 +464,23 @@ class CommandTests(TestCase):
         tester.activate()
         self.assertTrue(tester.active)
 
+    def test_processing_jobs(self):
+        exp_jids = ['6d368e16-2242-4cf8-87b4-a5dc40bb890b',
+                    '4c7115e8-4c8e-424c-bf25-96c292ca1931',
+                    'b72369f9-a886-4193-8d3d-f7b504168e75',
+                    '46b76f74-e100-47aa-9bf2-c0208bcea52d',
+                    '6ad4d590-4fa3-44d3-9a8f-ddbb472b1b5f',
+                    '063e553b-327c-4818-ab4a-adfe58e49860',
+                    'ac653cb5-76a6-4a45-929e-eb9b2dee6b63']
+        exp = [qdb.processing_job.ProcessingJob(j) for j in exp_jids]
+        self.assertCountEqual(qdb.software.Command(1).processing_jobs, exp)
+
+        exp_jids = ['bcc7ebcd-39c1-43e4-af2d-822e3589f14d']
+        exp = [qdb.processing_job.ProcessingJob(j) for j in exp_jids]
+        self.assertCountEqual(qdb.software.Command(2).processing_jobs, exp)
+
+        self.assertCountEqual(qdb.software.Command(4).processing_jobs, [])
+
 
 @qiita_test_checker()
 class SoftwareTestsIter(TestCase):


### PR DESCRIPTION
It has become more common to search/get all the jobs generated by a command; this method allows for easy access to this information. 