### PR TITLE
Fix 3070 retry

### DIFF
--- a/qiita_pet/handlers/artifact_handlers/tests/test_base_handlers.py
+++ b/qiita_pet/handlers/artifact_handlers/tests/test_base_handlers.py
@@ -27,6 +27,7 @@ from qiita_pet.handlers.artifact_handlers.base_handlers import (
     check_artifact_access, artifact_summary_get_request,
     artifact_summary_post_request, artifact_patch_request,
     artifact_post_req)
+from qiita_db.logger import LogEntry
 
 
 @qiita_test_checker()
@@ -362,6 +363,10 @@ class TestBaseHandlersUtils(TestCase):
         artifact_patch_request(test_user, 1, 'replace', '/visibility/',
                                req_value='sandbox')
         self.assertEqual(a.visibility, 'sandbox')
+        # checking that we have a new entry in the database for this
+        self.assertEqual(
+            LogEntry.newest_records(1)[0].msg,
+            'test@foo.bar changed artifact 1 (study 1) to sandbox')
 
         # Admin can change to private
         artifact_patch_request(User('admin@foo.bar'), 1, 'replace',


### PR DESCRIPTION
Long story short: https://github.com/qiita-spots/qiita/pull/3075/files added the change for programatic connections but not for GUI - in other words, is fine to have the other changes but we also _need_ this.

To make sure that it actually works as expected, I changed a visibility via GUI and checked the warnings:
![Screen Shot 2021-04-28 at 10 31 14 AM](https://user-images.githubusercontent.com/2014559/116439880-445e3d00-a80d-11eb-8ef9-5f6cce3d58c8.png)
