### PR TITLE
Fix 3050

### DIFF
--- a/qiita_db/artifact.py
+++ b/qiita_db/artifact.py
@@ -1511,8 +1511,8 @@ class Artifact(qdb.base.QiitaObject):
             cids = set(qdb.sql_connection.TRN.execute_fetchflatten())
 
             if dws:
-                cmds = set([n.default_parameter.command.id
-                            for w in dws for n in w.graph.nodes])
+                cmds = {n.default_parameter.command.id
+                        for w in dws for n in w.graph.nodes}
                 cids = cmds & cids
 
             return [qdb.software.Command(cid) for cid in cids]

--- a/qiita_db/software.py
+++ b/qiita_db/software.py
@@ -63,7 +63,7 @@ class Command(qdb.base.QiitaObject):
 
     @classmethod
     def get_commands_by_input_type(cls, artifact_types, active_only=True,
-                                   exclude_analysis=True):
+                                   exclude_analysis=True, prep_type=None):
         """Returns the commands that can process the given artifact types
 
         Parameters
@@ -94,8 +94,17 @@ class Command(qdb.base.QiitaObject):
             if exclude_analysis:
                 sql += " AND is_analysis = False"
             qdb.sql_connection.TRN.add(sql, [tuple(artifact_types)])
-            for c_id in qdb.sql_connection.TRN.execute_fetchflatten():
-                yield cls(c_id)
+            cids = set(qdb.sql_connection.TRN.execute_fetchflatten())
+
+            if prep_type is not None:
+                dws = [w for w in qdb.software.DefaultWorkflow.iter()
+                       if prep_type in w.data_type]
+                if dws:
+                    cmds = set([n.default_parameter.command.id
+                                for w in dws for n in w.graph.nodes])
+                    cids = cmds & cids
+
+            return [cls(cid) for cid in cids]
 
     @classmethod
     def get_html_generator(cls, artifact_type):

--- a/qiita_db/software.py
+++ b/qiita_db/software.py
@@ -100,8 +100,8 @@ class Command(qdb.base.QiitaObject):
                 dws = [w for w in qdb.software.DefaultWorkflow.iter()
                        if prep_type in w.data_type]
                 if dws:
-                    cmds = set([n.default_parameter.command.id
-                                for w in dws for n in w.graph.nodes])
+                    cmds = {n.default_parameter.command.id
+                            for w in dws for n in w.graph.nodes}
                     cids = cmds & cids
 
             return [cls(cid) for cid in cids]

--- a/qiita_db/test/test_artifact.py
+++ b/qiita_db/test/test_artifact.py
@@ -603,6 +603,22 @@ class ArtifactTestsReadOnly(TestCase):
         exp = []
         self.assertEqual(obs, exp)
 
+    def test_get_commands(self):
+        # we will check only ids for simplicity
+        # checking processing artifacts
+        obs = [c.id for c in qdb.artifact.Artifact(1).get_commands]
+        self.assertEqual(obs, [1])
+        obs = [c.id for c in qdb.artifact.Artifact(2).get_commands]
+        self.assertEqual(obs, [3])
+        # this is a biom in processing, so no commands should be available
+        obs = [c.id for c in qdb.artifact.Artifact(6).get_commands]
+        self.assertEqual(obs, [])
+
+        # checking analysis object - this is a biom in analysis, several
+        # commands should be available
+        obs = [c.id for c in qdb.artifact.Artifact(8).get_commands]
+        self.assertEqual(obs, [9, 10, 11, 12])
+
 
 @qiita_test_checker()
 class ArtifactTests(TestCase):

--- a/qiita_db/test/test_software.py
+++ b/qiita_db/test/test_software.py
@@ -74,6 +74,18 @@ class CommandTests(TestCase):
         exp = [qdb.software.Command(1), qdb.software.Command(2), new_cmd]
         self.assertCountEqual(obs, exp)
 
+        obs = list(qdb.software.Command.get_commands_by_input_type(
+            ['FASTQ'], active_only=False, exclude_analysis=False,
+            prep_type='Metagenomic'))
+        exp = [qdb.software.Command(1), new_cmd]
+        self.assertCountEqual(obs, exp)
+
+        obs = list(qdb.software.Command.get_commands_by_input_type(
+            ['FASTQ'], active_only=False, exclude_analysis=False,
+            prep_type='18S'))
+        exp = [qdb.software.Command(1)]
+        self.assertCountEqual(obs, exp)
+
     def test_get_html_artifact(self):
         with self.assertRaises(qdb.exceptions.QiitaDBError):
             qdb.software.Command.get_html_generator('BIOM')

--- a/qiita_pet/handlers/api_proxy/processing.py
+++ b/qiita_pet/handlers/api_proxy/processing.py
@@ -9,18 +9,19 @@
 from json import loads
 
 from qiita_db.user import User
+from qiita_db.artifact import Artifact
 from qiita_db.software import Command, Parameters, DefaultParameters
 from qiita_db.processing_job import ProcessingWorkflow, ProcessingJob
 from qiita_db.exceptions import QiitaDBUnknownIDError
 
 
-def list_commands_handler_get_req(artifact_types, exclude_analysis):
+def list_commands_handler_get_req(artifact_id, exclude_analysis):
     """Retrieves the commands that can process the given artifact types
 
     Parameters
     ----------
-    artifact_types : str
-        Comma-separated list of artifact types
+    artifact_id : int
+        artifact id
     exclude_analysis : bool
         If True, return commands that are not part of the analysis pipeline
 
@@ -34,11 +35,9 @@ def list_commands_handler_get_req(artifact_types, exclude_analysis):
                                        'command': str,
                                        'output': list of [str, str]}}
     """
-    artifact_types = artifact_types.split(',')
     cmd_info = [
         {'id': cmd.id, 'command': cmd.name, 'output': cmd.outputs}
-        for cmd in Command.get_commands_by_input_type(
-            artifact_types, exclude_analysis=exclude_analysis)]
+        for cmd in Artifact(artifact_id).get_commands]
 
     return {'status': 'success',
             'message': '',

--- a/qiita_pet/handlers/api_proxy/processing.py
+++ b/qiita_pet/handlers/api_proxy/processing.py
@@ -20,8 +20,8 @@ def list_commands_handler_get_req(artifact_id, exclude_analysis):
 
     Parameters
     ----------
-    artifact_id : int
-        artifact id
+    artifact_id : string
+        artifact id, it can be the integer or the name of the artifact
     exclude_analysis : bool
         If True, return commands that are not part of the analysis pipeline
 
@@ -35,9 +35,14 @@ def list_commands_handler_get_req(artifact_id, exclude_analysis):
                                        'command': str,
                                        'output': list of [str, str]}}
     """
-    cmd_info = [
-        {'id': cmd.id, 'command': cmd.name, 'output': cmd.outputs}
-        for cmd in Artifact(artifact_id).get_commands]
+    if artifact_id.isdigit():
+        commands = Artifact(artifact_id).get_commands
+    else:
+        commands = Command.get_commands_by_input_type(
+            [artifact_id], exclude_analysis=exclude_analysis)
+
+    cmd_info = [{'id': cmd.id, 'command': cmd.name, 'output': cmd.outputs}
+                for cmd in commands]
 
     return {'status': 'success',
             'message': '',

--- a/qiita_pet/handlers/study_handlers/processing.py
+++ b/qiita_pet/handlers/study_handlers/processing.py
@@ -19,10 +19,10 @@ class ListCommandsHandler(BaseHandler):
     def get(self):
         # Fun fact - if the argument is a list, JS adds '[]' to the
         # argument name
-        artifact_types = self.get_argument("artifact_types[]")
+        artifact_id = self.get_argument("artifact_id")
         exclude_analysis = self.get_argument('include_analysis') == 'false'
         self.write(
-            list_commands_handler_get_req(artifact_types, exclude_analysis))
+            list_commands_handler_get_req(artifact_id, exclude_analysis))
 
 
 class ListOptionsHandler(BaseHandler):

--- a/qiita_pet/static/js/networkVue.js
+++ b/qiita_pet/static/js/networkVue.js
@@ -613,7 +613,6 @@ Vue.component('processing-graph', {
      **/
     loadArtifactType: function(p_node) {
       let vm = this;
-      var types = [];
       var sel_artifacts_info = {};
       var node, nodeIdSplit, $rowDiv, $colDiv;
       var target = $("#processing-results");
@@ -632,10 +631,9 @@ Vue.component('processing-graph', {
         // This means that either we are going to process a new artifact (nodeIdSplit.length < 2)
         // or that the parent job generating this artifact type node is in construction.
         // In both of this cases, we can add a new job to the workflow
-        types.push(node.type);
         sel_artifacts_info[node.id] = {'type': node.type, 'name': node.label};
 
-        $.get(vm.portal + '/study/process/commands/', {artifact_types: types, include_analysis: vm.isAnalysisPipeline})
+        $.get(vm.portal + '/study/process/commands/', {artifact_id: node.id, include_analysis: vm.isAnalysisPipeline})
           .done(function (data) {
             target.empty();
 

--- a/qiita_pet/static/js/networkVue.js
+++ b/qiita_pet/static/js/networkVue.js
@@ -627,12 +627,13 @@ Vue.component('processing-graph', {
       p_node = String(p_node);
       nodeIdSplit = p_node.split(':');
       node = vm.network.getElementById(p_node).data();
+      root = vm.network.nodes()[0].id();
       if (nodeIdSplit.length < 2 || vm.network.getElementById(nodeIdSplit[0]).data().status === 'in_construction') {
         // This means that either we are going to process a new artifact (nodeIdSplit.length < 2)
         // or that the parent job generating this artifact type node is in construction.
         // In both of this cases, we can add a new job to the workflow
         sel_artifacts_info[node.id] = {'type': node.type, 'name': node.label};
-        artifact_id = nodeIdSplit.length < 2 ? node.id : node.type;
+        artifact_id = nodeIdSplit.length < 2 ? node.id : node.type + ':' + root ;
 
         $.get(vm.portal + '/study/process/commands/', {artifact_id: artifact_id, include_analysis: vm.isAnalysisPipeline})
           .done(function (data) {

--- a/qiita_pet/static/js/networkVue.js
+++ b/qiita_pet/static/js/networkVue.js
@@ -632,8 +632,9 @@ Vue.component('processing-graph', {
         // or that the parent job generating this artifact type node is in construction.
         // In both of this cases, we can add a new job to the workflow
         sel_artifacts_info[node.id] = {'type': node.type, 'name': node.label};
+        artifact_id = nodeIdSplit.length < 2 ? node.id : node.type;
 
-        $.get(vm.portal + '/study/process/commands/', {artifact_id: node.id, include_analysis: vm.isAnalysisPipeline})
+        $.get(vm.portal + '/study/process/commands/', {artifact_id: artifact_id, include_analysis: vm.isAnalysisPipeline})
           .done(function (data) {
             target.empty();
 

--- a/qiita_pet/static/js/networkVue.js
+++ b/qiita_pet/static/js/networkVue.js
@@ -773,6 +773,9 @@ Vue.component('processing-graph', {
       vm.network.ready(function() {
         if (vm.new_job_info !== null){
           vm.network.viewport(vm.new_job_info['viewport']);
+          node = vm.network.getElementById(vm.new_job_info.job_id);
+          // center in the children of the new job
+          vm.network.center(node.successors());
           vm.new_job_info = null;
         }
       });

--- a/qiita_pet/templates/study_ajax/artifact_file_selector.html
+++ b/qiita_pet/templates/study_ajax/artifact_file_selector.html
@@ -107,7 +107,7 @@
       // children
 
       if ((count_ok || (!is_required && num_children === 0))) {
-        if (($("#artifact-type").val() === 'per_sample_FASTQ') && (num_samples !== num_children)) {
+        if (is_required && ($("#artifact-type").val() === 'per_sample_FASTQ') && (num_samples != num_children)) {
           message = "per_sample_FASTQ expects one run_prefix per sample. Check for duplicate or missing run_prefix entries.";
           mark_as_wrong(this, message);
         } else {


### PR DESCRIPTION
Based on https://github.com/qiita-spots/qiita/pull/3096; please first review/merge that one.

The goal of adding/fixing #3050 is to limit the commands shown in the command list so commands that shouldn't be available; for example for per_sample_FASTQ Metageomic samples:
- current: <img width="204" alt="qiita" src="https://user-images.githubusercontent.com/2014559/116560541-b5a9f880-a8be-11eb-910c-55a5a08a4fba.png">
- this PR: <img width="202" alt="qiita-rc" src="https://user-images.githubusercontent.com/2014559/116560569-bd699d00-a8be-11eb-8ebd-765dba30cb3d.png">

At this stage we could also limit/remove the command that produced this artifact; for example, in the example above we could show the 2 options for the raw data but if the artifact has already been "Adaptor and host filtered" we could not show that option; thoughts @justinshaffer @adswafford ?