### PR TITLE
RESTful sample status

### DIFF
--- a/qiita_pet/handlers/rest/__init__.py
+++ b/qiita_pet/handlers/rest/__init__.py
@@ -8,7 +8,9 @@
 
 from .study import StudyHandler, StudyCreatorHandler, StudyStatusHandler
 from .study_samples import (StudySamplesHandler, StudySamplesInfoHandler,
-                            StudySamplesCategoriesHandler)
+                            StudySamplesCategoriesHandler,
+                            StudySamplesDetailHandler,
+                            StudySampleDetailHandler)
 from .study_person import StudyPersonHandler
 from .study_preparation import (StudyPrepCreatorHandler,
                                 StudyPrepArtifactCreatorHandler)
@@ -26,6 +28,9 @@ ENDPOINTS = (
     (r"/api/v1/study/([0-9]+)/samples/categories=([a-zA-Z\-0-9\.:,_]*)",
         StudySamplesCategoriesHandler),
     (r"/api/v1/study/([0-9]+)/samples", StudySamplesHandler),
+    (r"/api/v1/study/([0-9]+)/samples/status", StudySamplesDetailHandler),
+    (r"/api/v1/study/([0-9]+)/sample/([a-zA-Z\-0-9\.]+)/status",
+        StudySampleDetailHandler),
     (r"/api/v1/study/([0-9]+)/samples/info", StudySamplesInfoHandler),
     (r"/api/v1/person(.*)", StudyPersonHandler),
     (r"/api/v1/study/([0-9]+)/preparation/([0-9]+)/artifact",

--- a/qiita_pet/handlers/rest/study_samples.py
+++ b/qiita_pet/handlers/rest/study_samples.py
@@ -23,6 +23,9 @@ def _sample_details(study, samples):
                 'ebi_experiment_accession': None,
                 'preparation_visibility': None,
                 'preparation_type': None}
+
+        assert set(kwargs).issubset(set(base)), "Unexpected key to set"
+
         base.update(kwargs)
         return base
 

--- a/qiita_pet/handlers/rest/study_samples.py
+++ b/qiita_pet/handlers/rest/study_samples.py
@@ -30,7 +30,7 @@ def _sample_details(study, samples):
         return base
 
     # cache sample detail for lookup
-    study_samples = set(study.sample_template.keys())
+    study_samples = set(study.sample_template)
     sample_accessions = study.sample_template.ebi_sample_accessions
 
     # cache preparation information that we'll need
@@ -42,7 +42,7 @@ def _sample_details(study, samples):
         pt_light.append((pt.id, pt.ebi_experiment_accessions,
                          pt.status, pt.data_type()))
 
-        for ptsample in pt.keys():
+        for ptsample in pt:
             sample_prep_mapping[ptsample].append(idx)
 
     details = []

--- a/qiita_pet/test/rest/test_sample_detail.py
+++ b/qiita_pet/test/rest/test_sample_detail.py
@@ -1,0 +1,109 @@
+# -----------------------------------------------------------------------------
+# Copyright (c) 2014--, The Qiita Development Team.
+#
+# Distributed under the terms of the BSD 3-clause License.
+#
+# The full license is in the file LICENSE, distributed with this software.
+# -----------------------------------------------------------------------------
+
+from unittest import main
+
+from tornado.escape import json_decode
+
+from qiita_pet.test.rest.test_base import RESTHandlerTestCase
+
+
+class SampleDetailHandlerTests(RESTHandlerTestCase):
+    def test_get_missing_sample(self):
+        exp = [{'sample_id': 'doesnotexist',
+                'sample_found': False,
+                'ebi_sample_accession': None,
+                'preparation_id': None,
+                'ebi_experiment_accession': None,
+                'preparation_visibility': None,
+                'preparation_type': None}, ]
+
+        response = self.get('/api/v1/study/1/sample/doesnotexist/status',
+                            headers=self.headers)
+        self.assertEqual(response.code, 404)
+        obs = json_decode(response.body)
+        self.assertEqual(obs, exp)
+
+    def test_get_valid_sample(self):
+        exp = [{'sample_id': '1.SKD7.640191',
+                'sample_found': True,
+                'ebi_sample_accession': 'ERS000021',
+                'preparation_id': 1,
+                'exi_experiment_accession': 'ERX0000021',
+                'preparation_visibility': 'private',
+                'preparation_type': '18S'},
+               {'sample_id': '1.SKD7.640191',
+                'sample_found': True,
+                'ebi_sample_accession': 'ERS000021',
+                'preparation_id': 2,
+                'exi_experiment_accession': 'ERX0000021',
+                'preparation_visibility': 'private',
+                'preparation_type': '18S'}]
+
+        response = self.get('/api/v1/study/1/sample/1.SKD7.640191/status',
+                            headers=self.headers)
+        self.assertEqual(response.code, 200)
+        obs = json_decode(response.body)
+        self.assertEqual(obs, exp)
+
+    def test_post_samples_status_bad_request(self):
+        body = {'malformed': 'with garbage'}
+        response = self.post('/api/v1/study/1/samples/status',
+                             headers=self.headers,
+                             body=body, as_json=True)
+        self.assertEqual(response.code, 400)
+
+    def test_post_samples_status(self):
+        exp = [{'sample_id': '1.SKD7.640191',
+                'sample_found': True,
+                'ebi_sample_accession': 'ERS000021',
+                'preparation_id': 1,
+                'exi_experiment_accession': 'ERX0000021',
+                'preparation_visibility': 'private',
+                'preparation_type': '18S'},
+               {'sample_id': '1.SKD7.640191',
+                'sample_found': True,
+                'ebi_sample_accession': 'ERS000021',
+                'preparation_id': 2,
+                'exi_experiment_accession': 'ERX0000021',
+                'preparation_visibility': 'private',
+                'preparation_type': '18S'},
+               {'sample_id': 'doesnotexist',
+                'sample_found': False,
+                'ebi_sample_accession': None,
+                'preparation_id': None,
+                'ebi_experiment_accession': None,
+                'preparation_visibility': None,
+                'preparation_type': None},
+               {'sample_id': '1.SKD7.640177',
+                'sample_found': True,
+                'ebi_sample_accession': 'ERS000005',
+                'preparation_id': 1,
+                'exi_experiment_accession': 'ERX0000005',
+                'preparation_visibility': 'private',
+                'preparation_type': '18S'},
+               {'sample_id': '1.SKD7.640177',
+                'sample_found': True,
+                'ebi_sample_accession': 'ERS000005',
+                'preparation_id': 2,
+                'exi_experiment_accession': 'ERX0000005',
+                'preparation_visibility': 'private',
+                'preparation_type': '18S'}]
+
+        body = {'sample_ids': ['1.SKD7.640191', 'doesnotexist',
+                               '1.SKM5.640177']}
+        response = self.post('/api/v1/study/1/samples/status',
+                             headers=self.headers,
+                             body=body, as_json=True)
+        self.assertEqual(response.code, 200)
+        obs = json_decode(response.body)
+        self.assertEqual(obs, exp)
+
+
+if __name__ == '__main__':
+    main()

--- a/qiita_pet/test/rest/test_sample_detail.py
+++ b/qiita_pet/test/rest/test_sample_detail.py
@@ -6,11 +6,43 @@
 # The full license is in the file LICENSE, distributed with this software.
 # -----------------------------------------------------------------------------
 
-from unittest import main
+from unittest import main, TestCase
 
 from tornado.escape import json_decode
 
+import qiita_db
+
 from qiita_pet.test.rest.test_base import RESTHandlerTestCase
+from qiita_pet.handlers.rest.study_samples import _sample_details
+
+
+class SupportTests(TestCase):
+    def test_samples_detail(self):
+        exp = [{'sample_id': '1.SKD7.640191',
+                'sample_found': True,
+                'ebi_sample_accession': 'ERS000021',
+                'preparation_id': 1,
+                'ebi_experiment_accession': 'ERX0000021',
+                'preparation_visibility': 'private',
+                'preparation_type': '18S'},
+               {'sample_id': '1.SKD7.640191',
+                'sample_found': True,
+                'ebi_sample_accession': 'ERS000021',
+                'preparation_id': 2,
+                'ebi_experiment_accession': 'ERX0000021',
+                'preparation_visibility': 'private',
+                'preparation_type': '18S'},
+               {'sample_id': 'doesnotexist',
+                'sample_found': False,
+                'ebi_sample_accession': None,
+                'preparation_id': None,
+                'ebi_experiment_accession': None,
+                'preparation_visibility': None,
+                'preparation_type': None}]
+        obs = _sample_details(qiita_db.study.Study(1),
+                              ['1.SKD7.640191', 'doesnotexist'])
+        self.assertEqual(len(obs), len(exp))
+        self.assertEqual(obs, exp)
 
 
 class SampleDetailHandlerTests(RESTHandlerTestCase):
@@ -25,7 +57,7 @@ class SampleDetailHandlerTests(RESTHandlerTestCase):
 
         response = self.get('/api/v1/study/1/sample/doesnotexist/status',
                             headers=self.headers)
-        self.assertEqual(response.code, 404)
+        self.assertEqual(response.code, 200)
         obs = json_decode(response.body)
         self.assertEqual(obs, exp)
 
@@ -34,14 +66,14 @@ class SampleDetailHandlerTests(RESTHandlerTestCase):
                 'sample_found': True,
                 'ebi_sample_accession': 'ERS000021',
                 'preparation_id': 1,
-                'exi_experiment_accession': 'ERX0000021',
+                'ebi_experiment_accession': 'ERX0000021',
                 'preparation_visibility': 'private',
                 'preparation_type': '18S'},
                {'sample_id': '1.SKD7.640191',
                 'sample_found': True,
                 'ebi_sample_accession': 'ERS000021',
                 'preparation_id': 2,
-                'exi_experiment_accession': 'ERX0000021',
+                'ebi_experiment_accession': 'ERX0000021',
                 'preparation_visibility': 'private',
                 'preparation_type': '18S'}]
 
@@ -55,7 +87,7 @@ class SampleDetailHandlerTests(RESTHandlerTestCase):
         body = {'malformed': 'with garbage'}
         response = self.post('/api/v1/study/1/samples/status',
                              headers=self.headers,
-                             body=body, as_json=True)
+                             data=body, asjson=True)
         self.assertEqual(response.code, 400)
 
     def test_post_samples_status(self):
@@ -63,14 +95,14 @@ class SampleDetailHandlerTests(RESTHandlerTestCase):
                 'sample_found': True,
                 'ebi_sample_accession': 'ERS000021',
                 'preparation_id': 1,
-                'exi_experiment_accession': 'ERX0000021',
+                'ebi_experiment_accession': 'ERX0000021',
                 'preparation_visibility': 'private',
                 'preparation_type': '18S'},
                {'sample_id': '1.SKD7.640191',
                 'sample_found': True,
                 'ebi_sample_accession': 'ERS000021',
                 'preparation_id': 2,
-                'exi_experiment_accession': 'ERX0000021',
+                'ebi_experiment_accession': 'ERX0000021',
                 'preparation_visibility': 'private',
                 'preparation_type': '18S'},
                {'sample_id': 'doesnotexist',
@@ -80,18 +112,18 @@ class SampleDetailHandlerTests(RESTHandlerTestCase):
                 'ebi_experiment_accession': None,
                 'preparation_visibility': None,
                 'preparation_type': None},
-               {'sample_id': '1.SKD7.640177',
+               {'sample_id': '1.SKM5.640177',
                 'sample_found': True,
                 'ebi_sample_accession': 'ERS000005',
                 'preparation_id': 1,
-                'exi_experiment_accession': 'ERX0000005',
+                'ebi_experiment_accession': 'ERX0000005',
                 'preparation_visibility': 'private',
                 'preparation_type': '18S'},
-               {'sample_id': '1.SKD7.640177',
+               {'sample_id': '1.SKM5.640177',
                 'sample_found': True,
                 'ebi_sample_accession': 'ERS000005',
                 'preparation_id': 2,
-                'exi_experiment_accession': 'ERX0000005',
+                'ebi_experiment_accession': 'ERX0000005',
                 'preparation_visibility': 'private',
                 'preparation_type': '18S'}]
 
@@ -99,7 +131,7 @@ class SampleDetailHandlerTests(RESTHandlerTestCase):
                                '1.SKM5.640177']}
         response = self.post('/api/v1/study/1/samples/status',
                              headers=self.headers,
-                             body=body, as_json=True)
+                             data=body, asjson=True)
         self.assertEqual(response.code, 200)
         obs = json_decode(response.body)
         self.assertEqual(obs, exp)


### PR DESCRIPTION
This PR adds in the ability to query a study for detail on a specific sample or set of samples. The returned details include EBI accession information, and what preparations the sample was observed on. The output is represented in an flat fashion suitable to be fed directly into a `DataFrame` or `DataTable`. 

cc @dhakim87 @antgonza 