### PR TITLE
minimal fix for plugin testing

### DIFF
--- a/qiita_db/handlers/plugin.py
+++ b/qiita_db/handlers/plugin.py
@@ -250,10 +250,16 @@ class ReloadPluginAPItestHandler(OauthBaseHandler):
     def post(self):
         """Reloads the plugins"""
         conf_files = sorted(glob(join(qiita_config.plugin_dir, "*.conf")))
-        for fp in conf_files:
-            software = qdb.software.Software.from_file(fp, update=True)
-            software.activate()
-
-            software.register_commands()
+        software = set([qdb.software.Software.from_file(fp, update=True)
+                        for fp in conf_files])
+        definition = set(
+            [s for s in software if s.type == 'artifact definition'])
+        transformation = software - definition
+        for s in definition:
+            s.activate()
+            s.register_commands()
+        for s in transformation:
+            s.activate()
+            s.register_commands()
 
         self.finish()


### PR DESCRIPTION
While developing new plugins, I noticed that once in a while some will not load correctly. After further investigation, it resulted that if the plugin relied on a plugin-type and the plugin-type had a filename that was alphanumerically higher than the plugin - the system reset will fail because the plugin-type will not be added before the plugin. 

This PR makes sure that plugin-types are always activated before regular plugins; solving the above issue. 