### PR TITLE
allow artifact summary update

### DIFF
--- a/qiita_db/test/test_artifact.py
+++ b/qiita_db/test/test_artifact.py
@@ -1352,6 +1352,10 @@ class ArtifactTests(TestCase):
                        if x['fp_type'] == 'html_summary_dir']
         self.assertEqual(summary_dir, [])
 
+        # let's check if we update, we do _not_ remove the files
+        a.set_html_summary(exp3)
+        self.assertTrue(exists(a.html_summary_fp[1]))
+
     def test_descendants_with_jobs_one_element(self):
         artifact = qdb.artifact.Artifact.create(
             self.filepaths_root, 'FASTQ', prep_template=self.prep_template)

--- a/qiita_pet/handlers/artifact_handlers/base_handlers.py
+++ b/qiita_pet/handlers/artifact_handlers/base_handlers.py
@@ -242,7 +242,7 @@ def artifact_summary_get_request(user, artifact_id):
             'errored_summary_jobs': errored_summary_jobs}
 
 
-def artifact_summary_post_request(user, artifact_id):
+def artifact_summary_post_request(user, artifact_id, force_creation=False):
     """Launches the HTML summary generation and returns the job information
 
     Parameters
@@ -251,6 +251,8 @@ def artifact_summary_post_request(user, artifact_id):
         The user making the request
     artifact_id : int or str
         The artifact id
+    force_creation : bool
+        If all jobs should be ignored and it should force creation
 
     Returns
     -------
@@ -267,7 +269,7 @@ def artifact_summary_post_request(user, artifact_id):
     command = Command.get_html_generator(artifact.artifact_type)
     jobs = artifact.jobs(cmd=command)
     jobs = [j for j in jobs if j.status in ['queued', 'running', 'success']]
-    if jobs:
+    if not force_creation and jobs:
         # The HTML summary is either being generated or already generated.
         # Return the information of that job so we only generate the HTML
         # once - Magic number 0 -> we are ensuring that there is only one


### PR DESCRIPTION
This will allow us to update artifact summaries via: `artifact_summary_post_request(user, artifact_id, force_creation=True)` and while adding this, I realized that we were removing the current file if the file had the same name that the previous version. 