### PR TITLE
/api/v1/study/1/samples accepts new categories

### DIFF
--- a/qiita_pet/handlers/rest/study_samples.py
+++ b/qiita_pet/handlers/rest/study_samples.py
@@ -168,11 +168,11 @@ class StudySamplesHandler(RESTHandler):
 
         categories = set(study.sample_template.categories)
 
-        if set(data.columns) != categories:
-            if set(data.columns).issubset(categories):
-                self.fail('Not all sample information categories provided',
-                          400)
-                return
+        if set(data.columns) != categories and set(data.columns).issubset(
+                categories):
+            self.fail('Not all sample information categories provided',
+                      400)
+            return
 
         existing_samples = set(sample_info.index)
         overlapping_ids = set(data.index).intersection(existing_samples)

--- a/qiita_pet/handlers/rest/study_samples.py
+++ b/qiita_pet/handlers/rest/study_samples.py
@@ -193,7 +193,9 @@ class StudySamplesHandler(RESTHandler):
         if overlapping_ids:
             to_update = data.loc[overlapping_ids]
             study.sample_template.update(to_update)
-            status = 200
+            if status == 500:
+                # don't overwrite a possible status = 201
+                status = 200
 
         self.set_status(status)
         self.finish()

--- a/qiita_pet/handlers/rest/study_samples.py
+++ b/qiita_pet/handlers/rest/study_samples.py
@@ -168,8 +168,10 @@ class StudySamplesHandler(RESTHandler):
 
         categories = set(study.sample_template.categories)
 
-        if set(data.columns) != categories and set(data.columns).issubset(
-                categories):
+        # issuperset() will return True for true supersets or exact matches.
+        # In either case, keep processing. Subsets of categories remain
+        # invalid, however.
+        if not set(data.columns).issuperset(categories):
             self.fail('Not all sample information categories provided',
                       400)
             return

--- a/qiita_pet/test/rest/test_study_samples.py
+++ b/qiita_pet/test/rest/test_study_samples.py
@@ -213,7 +213,7 @@ class StudySamplesHandlerTests(RESTHandlerTestCase):
         body = _sample_creator(['1.SKM8.640201', 'blank.a1'])
         response = self.patch('/api/v1/study/1/samples', headers=self.headers,
                               data=body, asjson=True)
-        self.assertEqual(response.code, 200)
+        self.assertEqual(response.code, 201)
         # successful response should be empty string
         self.assertEqual(response.body, b'')
 
@@ -228,7 +228,7 @@ class StudySamplesHandlerTests(RESTHandlerTestCase):
 
         response = self.patch('/api/v1/study/1/samples', headers=self.headers,
                               data=body, asjson=True)
-        self.assertEqual(response.code, 200)
+        self.assertEqual(response.code, 201)
         # successful response should be empty string
         self.assertEqual(response.body, b'')
 


### PR DESCRIPTION
calling PATCH on /api/v1/study/1/samples now silently accepts metadata with new categories in them when updating a sample or adding a new one. Existing samples will be assigned a null value while samples in the metadata will be assigned the value or empty string if one was not given.