### PR TITLE
Fix #3237 Add prep ID to artifacts list included in an analysis

### DIFF
--- a/qiita_pet/handlers/analysis_handlers/base_handlers.py
+++ b/qiita_pet/handlers/analysis_handlers/base_handlers.py
@@ -74,9 +74,10 @@ def analysis_description_handler_get_request(analysis_id, user):
     artifacts = {}
     for aid, samples in analysis.samples.items():
         artifact = Artifact(aid)
+        foo = list(set([str(x.id) for x in artifact.prep_templates]))
         study = artifact.study
         artifacts[aid] = (
-            study.id, study.title, artifact.merging_scheme, samples)
+            study.id, study.title, artifact.merging_scheme, samples, foo)
 
     return {'analysis_name': analysis.name,
             'analysis_id': analysis.id,

--- a/qiita_pet/handlers/analysis_handlers/base_handlers.py
+++ b/qiita_pet/handlers/analysis_handlers/base_handlers.py
@@ -74,10 +74,10 @@ def analysis_description_handler_get_request(analysis_id, user):
     artifacts = {}
     for aid, samples in analysis.samples.items():
         artifact = Artifact(aid)
-        foo = list(set([str(x.id) for x in artifact.prep_templates]))
+        prep_ids = set([str(x.id) for x in artifact.prep_templates])
         study = artifact.study
         artifacts[aid] = (
-            study.id, study.title, artifact.merging_scheme, samples, foo)
+            study.id, study.title, artifact.merging_scheme, samples, prep_ids)
 
     return {'analysis_name': analysis.name,
             'analysis_id': analysis.id,

--- a/qiita_pet/handlers/analysis_handlers/tests/test_base_handlers.py
+++ b/qiita_pet/handlers/analysis_handlers/tests/test_base_handlers.py
@@ -45,18 +45,19 @@ class TestBaseHandlersUtils(TestCase):
                         'Soils', ('Pick closed-reference OTUs | Split '
                                   'libraries FASTQ', 'QIIME v1.9.1'), [
                             '1.SKB7.640196', '1.SKB8.640193', '1.SKD8.640184',
-                            '1.SKM4.640180', '1.SKM9.640192']),
+                            '1.SKM4.640180', '1.SKM9.640192'], ['1']),
                     5: (1, 'Identification of the Microbiomes for Cannabis '
                         'Soils', ('Pick closed-reference OTUs | Split '
                                   'libraries FASTQ', 'QIIME v1.9.1'), [
                             '1.SKB7.640196', '1.SKB8.640193', '1.SKD8.640184',
-                            '1.SKM4.640180', '1.SKM9.640192']),
+                            '1.SKM4.640180', '1.SKM9.640192'], ['1']),
                     6: (1, 'Identification of the Microbiomes for Cannabis '
                         'Soils', ('Pick closed-reference OTUs | Split '
                                   'libraries FASTQ', 'QIIME v1.9.1'), [
                             '1.SKB7.640196', '1.SKB8.640193', '1.SKD8.640184',
-                            '1.SKM4.640180', '1.SKM9.640192'])},
+                            '1.SKM4.640180', '1.SKM9.640192'], ['1'])},
                'alert_msg': ''}
+
         self.assertEqual(obs, exp)
 
         r_client.set('analysis_1', dumps({'job_id': 'job_id'}))
@@ -73,17 +74,17 @@ class TestBaseHandlersUtils(TestCase):
                         'Soils', ('Pick closed-reference OTUs | Split '
                                   'libraries FASTQ', 'QIIME v1.9.1'), [
                             '1.SKB7.640196', '1.SKB8.640193', '1.SKD8.640184',
-                            '1.SKM4.640180', '1.SKM9.640192']),
+                            '1.SKM4.640180', '1.SKM9.640192'], ['1']),
                     5: (1, 'Identification of the Microbiomes for Cannabis '
                         'Soils', ('Pick closed-reference OTUs | Split '
                                   'libraries FASTQ', 'QIIME v1.9.1'), [
                             '1.SKB7.640196', '1.SKB8.640193', '1.SKD8.640184',
-                            '1.SKM4.640180', '1.SKM9.640192']),
+                            '1.SKM4.640180', '1.SKM9.640192'], ['1']),
                     6: (1, 'Identification of the Microbiomes for Cannabis '
                         'Soils', ('Pick closed-reference OTUs | Split '
                                   'libraries FASTQ', 'QIIME v1.9.1'), [
                             '1.SKB7.640196', '1.SKB8.640193', '1.SKD8.640184',
-                            '1.SKM4.640180', '1.SKM9.640192'])},
+                            '1.SKM4.640180', '1.SKM9.640192'], ['1'])},
                'alert_msg': 'An artifact is being deleted from this analysis'}
         self.assertEqual(obs, exp)
 
@@ -103,17 +104,17 @@ class TestBaseHandlersUtils(TestCase):
                         'Soils', ('Pick closed-reference OTUs | Split '
                                   'libraries FASTQ', 'QIIME v1.9.1'), [
                             '1.SKB7.640196', '1.SKB8.640193', '1.SKD8.640184',
-                            '1.SKM4.640180', '1.SKM9.640192']),
+                            '1.SKM4.640180', '1.SKM9.640192'], ['1']),
                     5: (1, 'Identification of the Microbiomes for Cannabis '
                         'Soils', ('Pick closed-reference OTUs | Split '
                                   'libraries FASTQ', 'QIIME v1.9.1'), [
                             '1.SKB7.640196', '1.SKB8.640193', '1.SKD8.640184',
-                            '1.SKM4.640180', '1.SKM9.640192']),
+                            '1.SKM4.640180', '1.SKM9.640192'], ['1']),
                     6: (1, 'Identification of the Microbiomes for Cannabis '
                         'Soils', ('Pick closed-reference OTUs | Split '
                                   'libraries FASTQ', 'QIIME v1.9.1'), [
                             '1.SKB7.640196', '1.SKB8.640193', '1.SKD8.640184',
-                            '1.SKM4.640180', '1.SKM9.640192'])},
+                            '1.SKM4.640180', '1.SKM9.640192'], ['1'])},
                'alert_msg': 'Error deleting artifact'}
         self.assertEqual(obs, exp)
 
@@ -126,7 +127,7 @@ class TestBaseHandlersUtils(TestCase):
                'artifacts_being_deleted': [],
                'nodes': [
                     ('job', 'job', job_id, 'Single Rarefaction', 'success'),
-                    ('artifact', 'BIOM', 9, 'noname\n(BIOM)', 'artifact'),
+                    ('artifact', 'BIOM', 9, 'noname\n(BIOM)', 'outdated'),
                     ('artifact', 'BIOM',   8, 'noname\n(BIOM)', 'artifact')],
                'workflow': None}
         self.assertCountEqual(obs, exp)

--- a/qiita_pet/handlers/analysis_handlers/tests/test_base_handlers.py
+++ b/qiita_pet/handlers/analysis_handlers/tests/test_base_handlers.py
@@ -45,17 +45,17 @@ class TestBaseHandlersUtils(TestCase):
                         'Soils', ('Pick closed-reference OTUs | Split '
                                   'libraries FASTQ', 'QIIME v1.9.1'), [
                             '1.SKB7.640196', '1.SKB8.640193', '1.SKD8.640184',
-                            '1.SKM4.640180', '1.SKM9.640192'], ['1']),
+                            '1.SKM4.640180', '1.SKM9.640192'], {'1'}),
                     5: (1, 'Identification of the Microbiomes for Cannabis '
                         'Soils', ('Pick closed-reference OTUs | Split '
                                   'libraries FASTQ', 'QIIME v1.9.1'), [
                             '1.SKB7.640196', '1.SKB8.640193', '1.SKD8.640184',
-                            '1.SKM4.640180', '1.SKM9.640192'], ['1']),
+                            '1.SKM4.640180', '1.SKM9.640192'], {'1'}),
                     6: (1, 'Identification of the Microbiomes for Cannabis '
                         'Soils', ('Pick closed-reference OTUs | Split '
                                   'libraries FASTQ', 'QIIME v1.9.1'), [
                             '1.SKB7.640196', '1.SKB8.640193', '1.SKD8.640184',
-                            '1.SKM4.640180', '1.SKM9.640192'], ['1'])},
+                            '1.SKM4.640180', '1.SKM9.640192'], {'1'})},
                'alert_msg': ''}
 
         self.assertEqual(obs, exp)
@@ -74,17 +74,17 @@ class TestBaseHandlersUtils(TestCase):
                         'Soils', ('Pick closed-reference OTUs | Split '
                                   'libraries FASTQ', 'QIIME v1.9.1'), [
                             '1.SKB7.640196', '1.SKB8.640193', '1.SKD8.640184',
-                            '1.SKM4.640180', '1.SKM9.640192'], ['1']),
+                            '1.SKM4.640180', '1.SKM9.640192'], {'1'}),
                     5: (1, 'Identification of the Microbiomes for Cannabis '
                         'Soils', ('Pick closed-reference OTUs | Split '
                                   'libraries FASTQ', 'QIIME v1.9.1'), [
                             '1.SKB7.640196', '1.SKB8.640193', '1.SKD8.640184',
-                            '1.SKM4.640180', '1.SKM9.640192'], ['1']),
+                            '1.SKM4.640180', '1.SKM9.640192'], {'1'}),
                     6: (1, 'Identification of the Microbiomes for Cannabis '
                         'Soils', ('Pick closed-reference OTUs | Split '
                                   'libraries FASTQ', 'QIIME v1.9.1'), [
                             '1.SKB7.640196', '1.SKB8.640193', '1.SKD8.640184',
-                            '1.SKM4.640180', '1.SKM9.640192'], ['1'])},
+                            '1.SKM4.640180', '1.SKM9.640192'], {'1'})},
                'alert_msg': 'An artifact is being deleted from this analysis'}
         self.assertEqual(obs, exp)
 
@@ -104,17 +104,17 @@ class TestBaseHandlersUtils(TestCase):
                         'Soils', ('Pick closed-reference OTUs | Split '
                                   'libraries FASTQ', 'QIIME v1.9.1'), [
                             '1.SKB7.640196', '1.SKB8.640193', '1.SKD8.640184',
-                            '1.SKM4.640180', '1.SKM9.640192'], ['1']),
+                            '1.SKM4.640180', '1.SKM9.640192'], {'1'}),
                     5: (1, 'Identification of the Microbiomes for Cannabis '
                         'Soils', ('Pick closed-reference OTUs | Split '
                                   'libraries FASTQ', 'QIIME v1.9.1'), [
                             '1.SKB7.640196', '1.SKB8.640193', '1.SKD8.640184',
-                            '1.SKM4.640180', '1.SKM9.640192'], ['1']),
+                            '1.SKM4.640180', '1.SKM9.640192'], {'1'}),
                     6: (1, 'Identification of the Microbiomes for Cannabis '
                         'Soils', ('Pick closed-reference OTUs | Split '
                                   'libraries FASTQ', 'QIIME v1.9.1'), [
                             '1.SKB7.640196', '1.SKB8.640193', '1.SKD8.640184',
-                            '1.SKM4.640180', '1.SKM9.640192'], ['1'])},
+                            '1.SKM4.640180', '1.SKM9.640192'], {'1'})},
                'alert_msg': 'Error deleting artifact'}
         self.assertEqual(obs, exp)
 

--- a/qiita_pet/handlers/analysis_handlers/tests/test_base_handlers.py
+++ b/qiita_pet/handlers/analysis_handlers/tests/test_base_handlers.py
@@ -126,7 +126,7 @@ class TestBaseHandlersUtils(TestCase):
                'artifacts_being_deleted': [],
                'nodes': [
                     ('job', 'job', job_id, 'Single Rarefaction', 'success'),
-                    ('artifact', 'BIOM', 9, 'noname\n(BIOM)', 'outdated'),
+                    ('artifact', 'BIOM', 9, 'noname\n(BIOM)', 'artifact'),
                     ('artifact', 'BIOM',   8, 'noname\n(BIOM)', 'artifact')],
                'workflow': None}
         self.assertCountEqual(obs, exp)

--- a/qiita_pet/templates/analysis_description.html
+++ b/qiita_pet/templates/analysis_description.html
@@ -66,6 +66,7 @@
             <thead>
               <tr>
                 <th>Artifact ID</th>
+                <th>Prep IDs</th>
                 <th>Study Title</th>
                 <th>Parent Processing</th>
                 <th>Merging Scheme</th>
@@ -76,6 +77,7 @@
               {% for aid, data in artifacts.items() %}
                 <tr>
                   <td>{{aid}}</td>
+                  <td>{{', '.join(data[4])}}</td>
                   <td><a href="{% raw qiita_config.portal_dir %}/study/description/{{data[0]}}" target="_blank">{{data[1]}}</a></td>
                   <td>{{data[2][1]}}</td>
                   <td>{{data[2][0]}}</td>


### PR DESCRIPTION
Updated UI and API call to return a list of artifact.prep_template ids included in each analysis listed.
