### PR TITLE
fix #3219

### DIFF
--- a/qiita_pet/templates/study_ajax/add_prep_template.html
+++ b/qiita_pet/templates/study_ajax/add_prep_template.html
@@ -26,9 +26,6 @@ $(document).ready(function () {
     }
   });
 
-  // Make sure that the form gets validated prior submission
-  $("#create-prep-form").validate();
-
   // change the submit behavior
   $("#create-prep-form").submit(function(event){
     event.preventDefault();


### PR DESCRIPTION
To my knowledge, this appears to fix the outstanding issue. Validation of the two required fields is handled by bootstrap and jinja2. Unselected pulldowns will now display a default tool-tip bubble.