### PR TITLE
Add duplicates and tube_ids feature

### DIFF
--- a/qiita_pet/templates/sample_validation.html
+++ b/qiita_pet/templates/sample_validation.html
@@ -3,7 +3,7 @@
 <style>
     .column {
     float: left;
-    width: 25%;
+    width: 20%;
     }
 
     .row:after {
@@ -45,6 +45,14 @@
         <h2>Blank</h2>
         <ul>
             {% for sample in blank %}
+            <li>{{ sample }}</li>
+            {% end %}
+        </ul>
+    </div>
+    <div class="column">
+        <h2>Duplicates</h2>
+        <ul>
+            {% for sample in duplicates %}
             <li>{{ sample }}</li>
             {% end %}
         </ul>


### PR DESCRIPTION
Addresses issue #3275 

- Adds a duplicate column formatted like "SAMPLE_NAME × 2" if there are 2 copies of "SAMPLE_NAME"
- Removed all duplicates from all other columns (blanks, matching, extra)
- Added checking for tube_ids. If tube_ids are detected, will validate on tube_ids and will add the tube id after the sample name in listen (e.g. "SAMPLE_NAME (tube_id)")