### PR TITLE
fix 3222 via fp_type

### DIFF
--- a/qiita_db/util.py
+++ b/qiita_db/util.py
@@ -958,17 +958,17 @@ def move_filepaths_to_upload_folder(study_id, filepaths):
 
         path_builder = partial(join, uploads_fp)
 
-        # do not move these files back to upload folder.
-        do_not_move = ['qtp-sequencing-validate-data.csv', 'feature-table.qza']
+        # do not move these files-types back to upload folder.
+        do_not_move = ['preprocessed_fasta', 'preprocessed_fastq',
+                       'preprocessed_demux', 'directory', 'log',
+                       'html_summary', 'tgz', 'html_summary_dir', 'qzv', 'qza']
 
         # We can now go over and remove all the filepaths
         sql = """DELETE FROM qiita.filepath WHERE filepath_id = %s"""
         for x in filepaths:
             qdb.sql_connection.TRN.add(sql, [x['fp_id']])
 
-            if (x['fp_type'] in ('html_summary',
-                                 'html_summary_dir') or
-                    basename(x['fp']) in do_not_move):
+            if x['fp_type'] in do_not_move:
                 _rm_files(qdb.sql_connection.TRN, x['fp'])
                 continue
 


### PR DESCRIPTION
The [original fix](https://github.com/qiita-spots/qiita/pull/3241/files) relied on filenames, which meant that every new file (which depends on the plugins) needed to be added. This PR does the same but via the `fp_type`, which should substantially should reduce the need of adding new names. 