### PR TITLE
sync max body size

### DIFF
--- a/qiita_pet/nginx_example.conf
+++ b/qiita_pet/nginx_example.conf
@@ -3,6 +3,8 @@ events {
 }
 
 http {
+    client_max_body_size 4M;  # increase maximum body size from default 1M to match https://github.com/qiita-spots/qiita/blob/ac62aba5333f537c32e213855edc39c273aa9871/qiita_pet/static/vendor/js/resumable-uploader.js#L51
+
     # ports to redirect for mainqiita
     upstream mainqiita {
         server localhost:21174;


### PR DESCRIPTION
I am not totally sure if my analysis is accurate. Here is my understanding of the problem.

While setting up a qiita instance, we stumbled upon issues when uploaded files. File < chunk size were not affected. Also, this error only occurred when qiita run within the nginx setup, not as pure python instance. It looks like there is a default maximum body size for GET commands of [1M](http://nginx.org/en/docs/http/ngx_http_core_module.html#client_max_body_size) in nginx. Therefore, you might want to increase this size in the `nginx_example.conf` or at least leave a comment to inform others.
I have not tested to set this value to `3M`, but I recognized that the actual size of the payload various around 3400000 byte, thus some buffer could be useful.

Ideally, both values would be sources from a configure file instead of "hard coding" them into the javascript and the nginx config file.