### PR TITLE
fix environment_script for private plugins

### DIFF
--- a/.github/workflows/qiita-ci.yml
+++ b/.github/workflows/qiita-ci.yml
@@ -154,6 +154,8 @@ jobs:
 
           echo "5. Setting up qiita"
           conda activate qiita
+          # adapt environment_script for private qiita plugins from travis to github actions.
+          sed 's#export PATH="/home/travis/miniconda3/bin:$PATH"#source /home/runner/.profile#' -i qiita_db/support_files/patches/54.sql
           qiita-env make --no-load-ontologies
           qiita-test-install
           qiita plugins update

--- a/.github/workflows/qiita-ci.yml
+++ b/.github/workflows/qiita-ci.yml
@@ -155,7 +155,7 @@ jobs:
           echo "5. Setting up qiita"
           conda activate qiita
           # adapt environment_script for private qiita plugins from travis to github actions.
-          sed 's#export PATH="/home/travis/miniconda3/bin:$PATH"; source #source /home/runner/.profile#; conda ' -i qiita_db/support_files/patches/54.sql
+          sed 's#export PATH="/home/travis/miniconda3/bin:$PATH"; source #source /home/runner/.profile; conda #' -i qiita_db/support_files/patches/54.sql
           qiita-env make --no-load-ontologies
           qiita-test-install
           qiita plugins update

--- a/.github/workflows/qiita-ci.yml
+++ b/.github/workflows/qiita-ci.yml
@@ -155,7 +155,7 @@ jobs:
           echo "5. Setting up qiita"
           conda activate qiita
           # adapt environment_script for private qiita plugins from travis to github actions.
-          sed 's#export PATH="/home/travis/miniconda3/bin:$PATH"#source /home/runner/.profile#' -i qiita_db/support_files/patches/54.sql
+          sed 's#export PATH="/home/travis/miniconda3/bin:$PATH"; source #source /home/runner/.profile#; conda ' -i qiita_db/support_files/patches/54.sql
           qiita-env make --no-load-ontologies
           qiita-test-install
           qiita plugins update


### PR DESCRIPTION
I found that patch 54.sql for the test database uses an old conda activate mechanism for travis. We might want to fix this to the latest github action method of choice?