### PR TITLE
enable websocket communication

### DIFF
--- a/qiita_pet/nginx_example.conf
+++ b/qiita_pet/nginx_example.conf
@@ -13,6 +13,12 @@ http {
         server localhost:21177;
     }
 
+    # define variables for the actions that shall be taken for websocket handshake
+    map $http_upgrade $connection_upgrade {
+        default upgrade;
+        ''      close;
+    }
+
     # listening to 8080 and redirecting to https
     server {
            listen         8080;
@@ -54,6 +60,19 @@ http {
             # CHANGE ME: This should match the BASE_DATA_DIR in your qiita
             # config. E.g.,
             alias /Users/username/qiita/qiita_db/support_files/test_data/;
+        }
+
+        # enables communiction through websockets.
+        # Currently, only endpoints /consumer/, /analysis/selected/socket/, and /study/list/socket/ use websockets
+        location ~ ^/(consumer|analysis/selected/socket|study/list/socket)/ {
+            proxy_pass $scheme://mainqiita;
+            proxy_set_header Host $http_host;
+            proxy_redirect http:// https://;
+            proxy_http_version 1.1;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection $connection_upgrade;
+            proxy_set_header X-Forwarded-Host $http_host;
         }
 
         location / {


### PR DESCRIPTION
Addressing #3361 
extend the nginx example configuration file such that communication through WebSockets is automatically enabled.
I am not 100% sure if
  - [ ] the location definition is comprehensive. There might be more endpoints that need WebSocket communication
  - [x] the current settings cause unintended side effects
