### PR TITLE
Fix cmdname qp target gene

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Deployed on January 8th, 2024
 * Workflow definitions can now use sample or preparation information columns/values to differentiate between them.
 * Updated the Adapter and host filtering plugin (qp-fastp-minimap2) to v2023.12 addressing a bug in adapter filtering; [more information](https://qiita.ucsd.edu/static/doc/html/processingdata/qp-fastp-minimap2.html).
 * Other fixes: [3334](https://github.com/qiita-spots/qiita/pull/3334), [3338](https://github.com/qiita-spots/qiita/pull/3338). Thank you @sjanssen2.
-* The internal Sequence Processing Pipeline is now using the human pan-genome reference, together with the GRCh38 genome + PhiX and CHM13 genome for human host filtering.
+* The internal Sequence Processing Pipeline is now using the human pan-genome reference, together with the GRCh38 genome + PhiX and T2T-CHM13v2.0 genome for human host filtering.
 
 
 Version 2023.10

--- a/qiita_db/handlers/tests/test_plugin.py
+++ b/qiita_db/handlers/tests/test_plugin.py
@@ -88,7 +88,7 @@ class CommandListHandlerTests(OauthTestingBase):
         obs = self.post('/qiita_db/plugins/QIIMEq2/1.9.1/commands/', data=data,
                         headers=self.header)
         self.assertEqual(obs.code, 200)
-        obs = _get_command('QIIME', '1.9.1', 'New Command')
+        obs = _get_command('QIIMEq2', '1.9.1', 'New Command')
         self.assertEqual(obs.name, 'New Command')
         self.assertFalse(obs.analysis_only)
 

--- a/qiita_db/handlers/tests/test_plugin.py
+++ b/qiita_db/handlers/tests/test_plugin.py
@@ -106,10 +106,10 @@ class CommandListHandlerTests(OauthTestingBase):
             'default_parameter_sets': dumps({'dflt1': {'param1': 'test'}}),
             'analysis_only': True
         }
-        obs = self.post('/qiita_db/plugins/QIIME/1.9.1/commands/', data=data,
+        obs = self.post('/qiita_db/plugins/QIIMEq2/1.9.1/commands/', data=data,
                         headers=self.header)
         self.assertEqual(obs.code, 200)
-        obs = _get_command('QIIME', '1.9.1', 'New analysis command')
+        obs = _get_command('QIIMEq2', '1.9.1', 'New analysis command')
         self.assertEqual(obs.name, 'New analysis command')
         self.assertTrue(obs.analysis_only)
         self.assertEqual(obs.merging_scheme,

--- a/qiita_db/handlers/tests/test_plugin.py
+++ b/qiita_db/handlers/tests/test_plugin.py
@@ -18,7 +18,7 @@ import qiita_db as qdb
 
 class UtilTests(TestCase):
     def test_get_plugin(self):
-        obs = _get_plugin("QIIME", "1.9.1")
+        obs = _get_plugin("QIIMEq2", "1.9.1")
         exp = qdb.software.Software(1)
         self.assertEqual(obs, exp)
 
@@ -27,7 +27,7 @@ class UtilTests(TestCase):
             _get_plugin("QiIME", "1.9.1")
 
     def test_get_command(self):
-        obs = _get_command('QIIME', '1.9.1', 'Split libraries FASTQ')
+        obs = _get_command('QIIMEq2', '1.9.1', 'Split libraries FASTQ')
         exp = qdb.software.Command(1)
         self.assertEqual(obs, exp)
 
@@ -38,18 +38,18 @@ class UtilTests(TestCase):
 
 class PluginHandlerTests(OauthTestingBase):
     def test_get_plugin_does_not_exist(self):
-        obs = self.get('/qiita_db/plugins/QIIME/1.9.0/', headers=self.header)
+        obs = self.get('/qiita_db/plugins/QIIMEq2/1.9.0/', headers=self.header)
         self.assertEqual(obs.code, 404)
 
     def test_get_no_header(self):
-        obs = self.get('/qiita_db/plugins/QIIME/1.9.0/')
+        obs = self.get('/qiita_db/plugins/QIIMEq2/1.9.0/')
         self.assertEqual(obs.code, 400)
 
     def test_get(self):
-        obs = self.get('/qiita_db/plugins/QIIME/1.9.1/', headers=self.header)
+        obs = self.get('/qiita_db/plugins/QIIMEq2/1.9.1/', headers=self.header)
         self.assertEqual(obs.code, 200)
         exp = {
-            'name': 'QIIME',
+            'name': 'QIIMEq2',
             'version': '1.9.1',
             'description': 'Quantitative Insights Into Microbial Ecology '
                            '(QIIME) is an open-source bioinformatics pipeline '
@@ -125,12 +125,12 @@ class CommandHandlerTests(OauthTestingBase):
 
     def test_get_no_header(self):
         obs = self.get(
-            '/qiita_db/plugins/QIIME/1.9.1/commands/Split%20libraries/')
+            '/qiita_db/plugins/QIIMEq2/1.9.1/commands/Split%20libraries/')
         self.assertEqual(obs.code, 400)
 
     def test_get(self):
         obs = self.get(
-            '/qiita_db/plugins/QIIME/1.9.1/commands/Split%20libraries/',
+            '/qiita_db/plugins/QIIMEq2/1.9.1/commands/Split%20libraries/',
             headers=self.header)
         self.assertEqual(obs.code, 200)
         exp = {'name': 'Split libraries',
@@ -195,20 +195,20 @@ class CommandHandlerTests(OauthTestingBase):
 
 class CommandActivateHandlerTests(OauthTestingBase):
     def test_post_command_does_not_exist(self):
-        obs = self.post('/qiita_db/plugins/QIIME/1.9.1/commands/'
+        obs = self.post('/qiita_db/plugins/QIIMEq2/1.9.1/commands/'
                         'UNKNOWN/activate/',
                         headers=self.header, data={})
         self.assertEqual(obs.code, 404)
 
     def test_post_no_header(self):
-        obs = self.post('/qiita_db/plugins/QIIME/1.9.1/commands/'
+        obs = self.post('/qiita_db/plugins/QIIMEq2/1.9.1/commands/'
                         'Split%20libraries/activate/', data={})
         self.assertEqual(obs.code, 400)
 
     def test_post(self):
         qdb.software.Software.deactivate_all()
         self.assertFalse(qdb.software.Command(2).active)
-        obs = self.post('/qiita_db/plugins/QIIME/1.9.1/commands/'
+        obs = self.post('/qiita_db/plugins/QIIMEq2/1.9.1/commands/'
                         'Split%20libraries/activate/', headers=self.header,
                         data={})
         self.assertEqual(obs.code, 200)

--- a/qiita_db/handlers/tests/test_plugin.py
+++ b/qiita_db/handlers/tests/test_plugin.py
@@ -85,7 +85,7 @@ class CommandListHandlerTests(OauthTestingBase):
                            'param2': '2.4',
                            'param3': 'False'}})
             }
-        obs = self.post('/qiita_db/plugins/QIIME/1.9.1/commands/', data=data,
+        obs = self.post('/qiita_db/plugins/QIIMEq2/1.9.1/commands/', data=data,
                         headers=self.header)
         self.assertEqual(obs.code, 200)
         obs = _get_command('QIIME', '1.9.1', 'New Command')

--- a/qiita_db/handlers/tests/test_processing_job.py
+++ b/qiita_db/handlers/tests/test_processing_job.py
@@ -277,7 +277,8 @@ class ProcessingJobAPItestHandlerTests(OauthTestingBase):
     def test_post_processing_job(self):
         data = {
             'user': 'demo@microbio.me',
-            'command': dumps(['QIIME', '1.9.1', 'Pick closed-reference OTUs']),
+            'command': dumps(['QIIMEq2', '1.9.1',
+                              'Pick closed-reference OTUs']),
             'parameters': dumps({"reference": 1,
                                  "sortmerna_e_value": 1,
                                  "sortmerna_max_pos": 10000,
@@ -298,7 +299,8 @@ class ProcessingJobAPItestHandlerTests(OauthTestingBase):
     def test_post_processing_job_status(self):
         data = {
             'user': 'demo@microbio.me',
-            'command': dumps(['QIIME', '1.9.1', 'Pick closed-reference OTUs']),
+            'command': dumps(['QIIMEq2', '1.9.1',
+                              'Pick closed-reference OTUs']),
             'status': 'running',
             'parameters': dumps({"reference": 1,
                                  "sortmerna_e_value": 1,

--- a/qiita_db/support_files/patches/91.sql
+++ b/qiita_db/support_files/patches/91.sql
@@ -1,0 +1,15 @@
+-- Feb 19, 2024
+-- update qp-target-gene command name to "QIIMEq2" to be in sync with plugin repo
+--    When setting up a new instance of Qiita, we end up using qiita-env make
+--    which creates entries in the postgress database, also for qiita.software.
+--    One of these entries belongs to the qp-target-gene plugin with name "QIIME"
+--    and version "1.9.1". However, with 
+--    qp_target_gene/support_files/patches/171029_QIIME_v191_to_QIIMEq2_v191.sql
+--    the plugin was renamed into QIIMEq2, but this change was not relected in
+--    the qiita.software table. Thus, updating plugin information finds a mismatch
+--    between old (QIIME) and new (QIIMEq2) names and therefor creates a new
+--    command. However, the also provided default workflows hold command_ids to
+--    the old version and subsequently the commands for artifact processing
+--    will result in an empty list, even though the plugin is available.
+--    Therefore, this patch updates the name of QIIME.
+UPDATE qiita.software SET name = 'QIIMEq2' WHERE name = 'QIIME';

--- a/qiita_db/test/test_artifact.py
+++ b/qiita_db/test/test_artifact.py
@@ -472,7 +472,7 @@ class ArtifactTestsReadOnly(TestCase):
                           'QIIMEq2 v1.9.1'))
         self.assertEqual(qdb.artifact.Artifact(5).merging_scheme,
                          ('Pick closed-reference OTUs | Split libraries FASTQ',
-                          'QIIME v1.9.1'))
+                          'QIIMEq2 v1.9.1'))
 
     def test_jobs(self):
         # Returning all jobs

--- a/qiita_db/test/test_artifact.py
+++ b/qiita_db/test/test_artifact.py
@@ -469,7 +469,7 @@ class ArtifactTestsReadOnly(TestCase):
                          ('Split libraries FASTQ | N/A', 'N/A'))
         self.assertEqual(qdb.artifact.Artifact(4).merging_scheme,
                          ('Pick closed-reference OTUs | Split libraries FASTQ',
-                          'QIIME v1.9.1'))
+                          'QIIMEq2 v1.9.1'))
         self.assertEqual(qdb.artifact.Artifact(5).merging_scheme,
                          ('Pick closed-reference OTUs | Split libraries FASTQ',
                           'QIIME v1.9.1'))

--- a/qiita_db/test/test_meta_util.py
+++ b/qiita_db/test/test_meta_util.py
@@ -381,15 +381,15 @@ class MetaUtilTests(TestCase):
             'processed_data/1_study_1001_closed_reference_otu_table.biom\t'
             '%s\t%s\t4\tIllumina\t16S rRNA\t'
             'Pick closed-reference OTUs | Split libraries FASTQ\t'
-            'QIIME v1.9.1\tQIIME v1.9.1\n' % (fn_sample, fn_prep),
+            'QIIMEq2 v1.9.1\tQIIMEq2 v1.9.1\n' % (fn_sample, fn_prep),
             'processed_data/1_study_1001_closed_reference_otu_table.biom\t'
             '%s\t%s\t5\tIllumina\t16S rRNA\t'
             'Pick closed-reference OTUs | Split libraries FASTQ\t'
-            'QIIME v1.9.1\tQIIME v1.9.1\n' % (fn_sample, fn_prep),
+            'QIIMEq2 v1.9.1\tQIIMEq2 v1.9.1\n' % (fn_sample, fn_prep),
             'processed_data/1_study_1001_closed_reference_otu_table_Silva.bio'
             'm\t%s\t%s\t6\tIllumina\t16S rRNA\t'
             'Pick closed-reference OTUs | Split libraries FASTQ\t'
-            'QIIME v1.9.1\tQIIME v1.9.1' % (fn_sample, fn_prep)]
+            'QIIMEq2 v1.9.1\tQIIMEq2 v1.9.1' % (fn_sample, fn_prep)]
         self.assertEqual(txt_obs, txt_exp)
 
         # whatever the configuration was, we will change to settings so we can

--- a/qiita_db/test/test_meta_util.py
+++ b/qiita_db/test/test_meta_util.py
@@ -465,15 +465,15 @@ class MetaUtilTests(TestCase):
             'processed_data/1_study_1001_closed_reference_otu_table.biom\t'
             '%s\t%s\t4\tIllumina\t16S rRNA\t'
             'Pick closed-reference OTUs | Split libraries FASTQ\t'
-            'QIIME v1.9.1\tQIIME v1.9.1\n' % (fn_sample, fn_prep),
+            'QIIMEq2 v1.9.1\tQIIMEq2 v1.9.1\n' % (fn_sample, fn_prep),
             'processed_data/1_study_1001_closed_reference_otu_table.biom\t'
             '%s\t%s\t5\tIllumina\t16S rRNA\t'
             'Pick closed-reference OTUs | Split libraries FASTQ\t'
-            'QIIME v1.9.1\tQIIME v1.9.1\n' % (fn_sample, fn_prep),
+            'QIIMEq2 v1.9.1\tQIIMEq2 v1.9.1\n' % (fn_sample, fn_prep),
             'processed_data/1_study_1001_closed_reference_otu_table_Silva.bio'
             'm\t%s\t%s\t6\tIllumina\t16S rRNA\t'
             'Pick closed-reference OTUs | Split libraries FASTQ'
-            '\tQIIME v1.9.1\tQIIME v1.9.1' % (fn_sample, fn_prep)]
+            '\tQIIMEq2 v1.9.1\tQIIMEq2 v1.9.1' % (fn_sample, fn_prep)]
         self.assertEqual(txt_obs, txt_exp)
 
         # returning configuration

--- a/qiita_db/test/test_software.py
+++ b/qiita_db/test/test_software.py
@@ -342,7 +342,7 @@ class CommandTests(TestCase):
                 self.outputs)
 
         # the output type doesn't exist
-        with self.assertRaisesRegex(ValueError, "Error creating QIIME, Split "
+        with self.assertRaisesRegex(ValueError, "Error creating QIIMEq2, Split "
                                     "libraries - wrong output, This is a "
                                     "command for testing - Unknown "
                                     "artifact_type: BLA!"):
@@ -567,7 +567,7 @@ class SoftwareTests(TestCase):
                 remove(f)
 
     def test_from_name_and_version(self):
-        obs = qdb.software.Software.from_name_and_version('QIIME', '1.9.1')
+        obs = qdb.software.Software.from_name_and_version('QIIMEq2', '1.9.1')
         exp = qdb.software.Software(1)
         self.assertEqual(obs, exp)
 
@@ -578,13 +578,13 @@ class SoftwareTests(TestCase):
 
         # Wrong name
         with self.assertRaises(qdb.exceptions.QiitaDBUnknownIDError):
-            qdb.software.Software.from_name_and_version('QiIME', '1.9.1')
+            qdb.software.Software.from_name_and_version('QiIMEq2', '1.9.1')
         # Wrong version
         with self.assertRaises(qdb.exceptions.QiitaDBUnknownIDError):
-            qdb.software.Software.from_name_and_version('QIIME', '1.9.0')
+            qdb.software.Software.from_name_and_version('QIIMEq2', '1.9.0')
 
     def test_name(self):
-        self.assertEqual(qdb.software.Software(1).name, "QIIME")
+        self.assertEqual(qdb.software.Software(1).name, "QIIMEq2")
 
     def test_version(self):
         self.assertEqual(qdb.software.Software(1).version, "1.9.1")
@@ -694,7 +694,7 @@ class SoftwareTests(TestCase):
         self._clean_up_files.append(fp)
         with open(fp, 'w') as f:
             f.write(CONF_TEMPLATE %
-                    ('QIIME', '1.9.1',
+                    ('QIIMEq2', '1.9.1',
                      'Quantitative Insights Into Microbial Ecology (QIIME) '
                      'is an open-source bioinformatics pipeline for '
                      'performing microbiome analysis from raw DNA '
@@ -829,7 +829,7 @@ class SoftwareTests(TestCase):
         self.assertEqual(obs.client_secret, 'client_secret')
 
     def test_exists(self):
-        self.assertTrue(qdb.software.Software.exists("QIIME", "1.9.1"))
+        self.assertTrue(qdb.software.Software.exists("QIIMEq2", "1.9.1"))
         self.assertFalse(qdb.software.Software.exists("NewPlugin", "1.9.1"))
         self.assertFalse(qdb.software.Software.exists("QIIME", "2.0.0"))
 

--- a/qiita_db/test/test_software.py
+++ b/qiita_db/test/test_software.py
@@ -711,7 +711,7 @@ class SoftwareTests(TestCase):
         self._clean_up_files.append(fp)
         with open(fp, 'w') as f:
             f.write(CONF_TEMPLATE %
-                    ('QIIME', '1.9.1', 'Different description',
+                    ('QIIMEq2', '1.9.1', 'Different description',
                      'source activate qiime', 'start_qiime',
                      'artifact transformation',
                      '[["10.1038/nmeth.f.303", "20383131"]]', client_id,
@@ -719,10 +719,10 @@ class SoftwareTests(TestCase):
         with warnings.catch_warnings(record=True) as warns:
             obs = qdb.software.Software.from_file(fp)
             obs_warns = [str(w.message) for w in warns]
-            exp_warns = ['Plugin "QIIME" version "1.9.1" config file does not '
-                         'match with stored information. Check the config file'
-                         ' or run "qiita plugin update" to update the plugin '
-                         'information. Offending values: description, '
+            exp_warns = ['Plugin "QIIMEq2" version "1.9.1" config file does '
+                         'not match with stored information. Check the config '
+                         'file or run "qiita plugin update" to update the '
+                         'plugin information. Offending values: description, '
                          'environment_script, start_script']
             self.assertCountEqual(obs_warns, exp_warns)
 

--- a/qiita_db/test/test_software.py
+++ b/qiita_db/test/test_software.py
@@ -342,8 +342,8 @@ class CommandTests(TestCase):
                 self.outputs)
 
         # the output type doesn't exist
-        with self.assertRaisesRegex(ValueError, "Error creating QIIMEq2, Split "
-                                    "libraries - wrong output, This is a "
+        with self.assertRaisesRegex(ValueError, "Error creating QIIMEq2, Split"
+                                    " libraries - wrong output, This is a "
                                     "command for testing - Unknown "
                                     "artifact_type: BLA!"):
             qdb.software.Command.create(

--- a/qiita_pet/handlers/analysis_handlers/tests/test_base_handlers.py
+++ b/qiita_pet/handlers/analysis_handlers/tests/test_base_handlers.py
@@ -43,17 +43,17 @@ class TestBaseHandlersUtils(TestCase):
                'artifacts': {
                     4: (1, 'Identification of the Microbiomes for Cannabis '
                         'Soils', ('Pick closed-reference OTUs | Split '
-                                  'libraries FASTQ', 'QIIME v1.9.1'), [
+                                  'libraries FASTQ', 'QIIMEq2 v1.9.1'), [
                             '1.SKB7.640196', '1.SKB8.640193', '1.SKD8.640184',
                             '1.SKM4.640180', '1.SKM9.640192'], {'1'}),
                     5: (1, 'Identification of the Microbiomes for Cannabis '
                         'Soils', ('Pick closed-reference OTUs | Split '
-                                  'libraries FASTQ', 'QIIME v1.9.1'), [
+                                  'libraries FASTQ', 'QIIMEq2 v1.9.1'), [
                             '1.SKB7.640196', '1.SKB8.640193', '1.SKD8.640184',
                             '1.SKM4.640180', '1.SKM9.640192'], {'1'}),
                     6: (1, 'Identification of the Microbiomes for Cannabis '
                         'Soils', ('Pick closed-reference OTUs | Split '
-                                  'libraries FASTQ', 'QIIME v1.9.1'), [
+                                  'libraries FASTQ', 'QIIMEq2 v1.9.1'), [
                             '1.SKB7.640196', '1.SKB8.640193', '1.SKD8.640184',
                             '1.SKM4.640180', '1.SKM9.640192'], {'1'})},
                'analysis_reservation': '',

--- a/qiita_pet/handlers/analysis_handlers/tests/test_base_handlers.py
+++ b/qiita_pet/handlers/analysis_handlers/tests/test_base_handlers.py
@@ -72,17 +72,17 @@ class TestBaseHandlersUtils(TestCase):
                'artifacts': {
                     4: (1, 'Identification of the Microbiomes for Cannabis '
                         'Soils', ('Pick closed-reference OTUs | Split '
-                                  'libraries FASTQ', 'QIIME v1.9.1'), [
+                                  'libraries FASTQ', 'QIIMEq2 v1.9.1'), [
                             '1.SKB7.640196', '1.SKB8.640193', '1.SKD8.640184',
                             '1.SKM4.640180', '1.SKM9.640192'], {'1'}),
                     5: (1, 'Identification of the Microbiomes for Cannabis '
                         'Soils', ('Pick closed-reference OTUs | Split '
-                                  'libraries FASTQ', 'QIIME v1.9.1'), [
+                                  'libraries FASTQ', 'QIIMEq2 v1.9.1'), [
                             '1.SKB7.640196', '1.SKB8.640193', '1.SKD8.640184',
                             '1.SKM4.640180', '1.SKM9.640192'], {'1'}),
                     6: (1, 'Identification of the Microbiomes for Cannabis '
                         'Soils', ('Pick closed-reference OTUs | Split '
-                                  'libraries FASTQ', 'QIIME v1.9.1'), [
+                                  'libraries FASTQ', 'QIIMEq2 v1.9.1'), [
                             '1.SKB7.640196', '1.SKB8.640193', '1.SKD8.640184',
                             '1.SKM4.640180', '1.SKM9.640192'], {'1'})},
                'alert_msg': 'An artifact is being deleted from this analysis',
@@ -103,17 +103,17 @@ class TestBaseHandlersUtils(TestCase):
                'artifacts': {
                     4: (1, 'Identification of the Microbiomes for Cannabis '
                         'Soils', ('Pick closed-reference OTUs | Split '
-                                  'libraries FASTQ', 'QIIME v1.9.1'), [
+                                  'libraries FASTQ', 'QIIMEq2 v1.9.1'), [
                             '1.SKB7.640196', '1.SKB8.640193', '1.SKD8.640184',
                             '1.SKM4.640180', '1.SKM9.640192'], {'1'}),
                     5: (1, 'Identification of the Microbiomes for Cannabis '
                         'Soils', ('Pick closed-reference OTUs | Split '
-                                  'libraries FASTQ', 'QIIME v1.9.1'), [
+                                  'libraries FASTQ', 'QIIMEq2 v1.9.1'), [
                             '1.SKB7.640196', '1.SKB8.640193', '1.SKD8.640184',
                             '1.SKM4.640180', '1.SKM9.640192'], {'1'}),
                     6: (1, 'Identification of the Microbiomes for Cannabis '
                         'Soils', ('Pick closed-reference OTUs | Split '
-                                  'libraries FASTQ', 'QIIME v1.9.1'), [
+                                  'libraries FASTQ', 'QIIMEq2 v1.9.1'), [
                             '1.SKB7.640196', '1.SKB8.640193', '1.SKD8.640184',
                             '1.SKM4.640180', '1.SKM9.640192'], {'1'})},
                'alert_msg': 'Error deleting artifact',

--- a/qiita_pet/handlers/api_proxy/tests/test_processing.py
+++ b/qiita_pet/handlers/api_proxy/tests/test_processing.py
@@ -103,7 +103,7 @@ class TestProcessingAPIReadOnly(TestCase):
             'command': 'Split libraries FASTQ',
             'command_description': 'Demultiplexes and applies quality '
                                    'control to FASTQ data',
-            'software': 'QIIME',
+            'software': 'QIIMEq2',
             'software_version': '1.9.1'}
         self.assertEqual(obs, exp)
 

--- a/qiita_pet/handlers/artifact_handlers/tests/test_base_handlers.py
+++ b/qiita_pet/handlers/artifact_handlers/tests/test_base_handlers.py
@@ -258,7 +258,7 @@ class TestBaseHandlersUtils(TestCase):
                    'rev_comp_mapping_barcodes': 'False',
                    'min_per_read_length_fraction': '0.75',
                    'barcode_type': 'golay_12'},
-                 'software_version': '1.9.1', 'software': 'QIIME'},
+                 'software_version': '1.9.1', 'software': 'QIIMEq2'},
                'files': exp_files,
                'is_from_analysis': False,
                'summary': None,

--- a/qiita_pet/handlers/study_handlers/tests/test_processing.py
+++ b/qiita_pet/handlers/study_handlers/tests/test_processing.py
@@ -99,7 +99,7 @@ class TestJobAJAX(TestHandlerBase):
             'command': 'Split libraries FASTQ',
             'command_description': 'Demultiplexes and applies quality '
                                    'control to FASTQ data',
-            'software': 'QIIME',
+            'software': 'QIIMEq2',
             'software_version': '1.9.1'}
         self.assertEqual(loads(response.body), exp)
 


### PR DESCRIPTION
Addressing #3363 by renaming the qp-target-gene command name to "QIIMEq2"