### PR TITLE
make help email address configurable instead of hard coding

### DIFF
--- a/qiita_core/configuration_manager.py
+++ b/qiita_core/configuration_manager.py
@@ -117,6 +117,12 @@ class ConfigurationManager(object):
         The script used to start the plugins
     plugin_dir : str
         The path to the directory containing the plugin configuration files
+    help_email : str
+        The email address a user should write to when asking for help
+        Defaults to qiita.help@gmail.com
+    sysadmin_email : str
+        The email address, Qiita sends internal notifications to a sys admin
+        Defaults to jdereus@health.ucsd.edu
 
     Raises
     ------
@@ -233,6 +239,14 @@ class ConfigurationManager(object):
         if not self.key_file:
             self.key_file = join(install_dir, 'qiita_core', 'support_files',
                                  'ci_server.key')
+
+        self.help_email = config.get('main', 'HELP_EMAIL')
+        if not self.help_email:
+            self.help_email = 'qiita.help@gmail.com'
+
+        self.sysadmin_email = config.get('main', 'SYSADMIN_EMAIL')
+        if not self.sysadmin_email:
+            self.sysadmin_email = 'jdereus@health.ucsd.edu'
 
     def _get_job_scheduler(self, config):
         """Get the configuration of the job_scheduler section"""

--- a/qiita_core/support_files/config_test.cfg
+++ b/qiita_core/support_files/config_test.cfg
@@ -68,6 +68,12 @@ COOKIE_SECRET = SECRET
 # The value used to secure JWTs for delegated permission artifact download.
 JWT_SECRET = SUPER_SECRET
 
+# Address a user should write to when asking for help, default to qiita.help@gmail.com
+HELP_EMAIL =
+
+# The email address, Qiita sends internal notifications to a sys admin
+SYSADMIN_EMAIL =
+
 # ----------------------------- SMTP settings -----------------------------
 [smtp]
 # The hostname to connect to

--- a/qiita_core/tests/test_configuration_manager.py
+++ b/qiita_core/tests/test_configuration_manager.py
@@ -180,6 +180,24 @@ class ConfigurationManagerTests(TestCase):
 
         self.assertEqual(obs.qiita_env, "")
 
+    def test_help_email(self):
+        obs = ConfigurationManager()
+
+        obs._get_main(self.conf)
+        self.assertEqual(obs.help_email, 'foo@bar.com')
+        self.assertEqual(obs.sysadmin_email, 'jeff@bar.com')
+
+        # test if it falls back to qiita.help@gmail.com
+        self.conf.set('main', 'HELP_EMAIL', '')
+        obs._get_main(self.conf)
+        self.assertEqual(obs.help_email, 'qiita.help@gmail.com')
+
+        # test if it falls back to qiita.help@gmail.com
+        self.conf.set('main', 'SYSADMIN_EMAIL', '')
+        obs._get_main(self.conf)
+        self.assertEqual(obs.sysadmin_email, 'jdereus@health.ucsd.edu')
+
+
     def test_get_job_scheduler(self):
         obs = ConfigurationManager()
 
@@ -273,6 +291,12 @@ COOKIE_SECRET = SECRET
 
 # The value used to secure JWTs for delegated permission artifact download.
 JWT_SECRET = SUPER_SECRET
+
+# Address a user should write to when asking for help
+HELP_EMAIL = foo@bar.com
+
+# The email address, Qiita sends internal notifications to a sys admin
+SYSADMIN_EMAIL = jeff@bar.com
 
 # ----------------------------- SMTP settings -----------------------------
 [smtp]

--- a/qiita_db/processing_job.py
+++ b/qiita_db/processing_job.py
@@ -493,7 +493,7 @@ class ProcessingJob(qdb.base.QiitaObject):
                 samples, columns, input_size = self.shape
                 parts = []
                 error_msg = ('Obvious incorrect allocation. Please '
-                             'contact qiita.help@gmail.com')
+                             'contact %s' % qiita_config.help_email)
                 for part in allocation.split('--'):
                     param = ''
                     if part.startswith('time '):
@@ -902,7 +902,7 @@ class ProcessingJob(qdb.base.QiitaObject):
                 if self.user.level in {'admin', 'wet-lab admin'}:
                     if value == 'error':
                         qdb.util.send_email(
-                            'jdereus@health.ucsd.edu', msg['subject'],
+                            qiita_config.sysadmin_email, msg['subject'],
                             msg['message'])
 
             sql = """UPDATE qiita.processing_job

--- a/qiita_pet/handlers/artifact_handlers/base_handlers.py
+++ b/qiita_pet/handlers/artifact_handlers/base_handlers.py
@@ -370,7 +370,7 @@ def artifact_patch_request(user, artifact_id, req_op, req_path, req_value=None,
 
             sid = artifact.study.id
             if artifact.visibility == 'awaiting_approval':
-                email_to = 'qiita.help@gmail.com'
+                email_to = qiita_config.help_email
                 subject = ('QIITA: Artifact %s awaiting_approval. Study %d, '
                            'Prep %d' % (artifact_id, sid,
                                         artifact.prep_templates[0].id))

--- a/qiita_pet/handlers/auth_handlers.py
+++ b/qiita_pet/handlers/auth_handlers.py
@@ -62,8 +62,8 @@ class AuthCreateHandler(BaseHandler):
                               url_escape(username), url))
             except Exception:
                 msg = ("Unable to send verification email. Please contact the "
-                       "qiita developers at <a href='mailto:qiita.help"
-                       "@gmail.com'>qiita.help@gmail.com</a>")
+                       "qiita developers at <a href='mailto:%s'>%s</a>") % (
+                       qiita_config.help_email, qiita_config.help_email)
                 self.redirect(u"%s/?level=danger&message=%s"
                               % (qiita_config.portal_dir, url_escape(msg)))
                 return
@@ -75,8 +75,9 @@ class AuthCreateHandler(BaseHandler):
                    "<p>If you don't receive your activation email within a "
                    "couple of minutes, check your spam folder. If you still "
                    "don't see it, send us an email at <a "
-                   "href=\"mailto:qiita.help@gmail.com\">qiita.help@gmail.com"
-                   "</a>.</p>")
+                   "href=\"mailto:%s\">%s"
+                   "</a>.</p>") % (qiita_config.help_email,
+                                   qiita_config.help_email)
             self.redirect(u"%s/?level=success&message=%s" %
                           (qiita_config.portal_dir, url_escape(msg)))
         else:
@@ -135,7 +136,8 @@ class AuthLoginHandler(BaseHandler):
                        "the verify link. You may need to check your spam "
                        "folder to find the email.<br/>If a verification email"
                        " has not arrived in 15 minutes, please email <a href='"
-                       "mailto:qiita.help@gmail.com'>qiita.help@gmail.com</a>")
+                       "mailto:%s'>%s</a>") % (qiita_config.help_email,
+                                               qiita_config.help_email)
         except QiitaDBUnknownIDError:
             msg = "Unknown user"
         except RuntimeError:

--- a/qiita_pet/handlers/download.py
+++ b/qiita_pet/handlers/download.py
@@ -445,12 +445,12 @@ class DownloadPublicHandler(BaseHandlerDownload):
                 public_raw_download = study.public_raw_download
                 if study.status != 'public':
                     raise HTTPError(404, reason='Study is not public. If this '
-                                    'is a mistake contact: '
-                                    'qiita.help@gmail.com')
+                                    'is a mistake contact: %s' %
+                                    qiita_config.help_email)
                 elif data == 'raw' and not public_raw_download:
                     raise HTTPError(422, reason='No raw data access. If this '
-                                    'is a mistake contact: '
-                                    'qiita.help@gmail.com')
+                                    'is a mistake contact: %s'
+                                    % qiita_config.help_email)
                 else:
                     # raw data
                     artifacts = [a for a in study.artifacts(dtype=data_type)
@@ -466,8 +466,8 @@ class DownloadPublicHandler(BaseHandlerDownload):
 
                 if not to_download:
                     raise HTTPError(422, reason='Nothing to download. If '
-                                    'this is a mistake contact: '
-                                    'qiita.help@gmail.com')
+                                    'this is a mistake contact: %s'
+                                    % qiita_config.help_email)
                 else:
                     self._write_nginx_file_list(to_download)
 
@@ -496,18 +496,18 @@ class DownloadPublicArtifactHandler(BaseHandlerDownload):
             else:
                 if artifact.visibility != 'public':
                     raise HTTPError(404, reason='Artifact is not public. If '
-                                    'this is a mistake contact: '
-                                    'qiita.help@gmail.com')
+                                    'this is a mistake contact: %s'
+                                    % qiita_config.help_email)
                 elif artifact.has_human:
                     raise HTTPError(404, reason='Artifact has possible human '
                                     'sequences. If this is a mistake contact: '
-                                    'qiita.help@gmail.com')
+                                    '%s' % qiita_config.help_email)
                 else:
                     to_download = self._list_artifact_files_nginx(artifact)
                     if not to_download:
                         raise HTTPError(422, reason='Nothing to download. If '
-                                        'this is a mistake contact: '
-                                        'qiita.help@gmail.com')
+                                        'this is a mistake contact: %s'
+                                        % qiita_config.help_email)
                     else:
                         self._write_nginx_file_list(to_download)
 
@@ -600,8 +600,8 @@ class DownloadPrivateArtifactHandler(BaseHandlerDownload):
         to_download = self._list_artifact_files_nginx(artifact)
         if not to_download:
             raise HTTPError(422, reason='Nothing to download. If '
-                                        'this is a mistake contact: '
-                                        'qiita.help@gmail.com')
+                                        'this is a mistake contact: %s' %
+                                        qiita_config.help_email)
         else:
             self._write_nginx_file_list(to_download)
 

--- a/qiita_pet/handlers/study_handlers/sample_template.py
+++ b/qiita_pet/handlers/study_handlers/sample_template.py
@@ -214,8 +214,8 @@ def sample_template_handler_patch_request(user, req_op, req_path,
                 # the system
                 filepath = req_value
                 if not exists(filepath):
-                    reason = ('Upload file not found (%s), please report to '
-                              'qiita.help@gmail.com' % filepath)
+                    reason = ('Upload file not found (%s), please report to %s'
+                              % (filepath, qiita_config.help_email))
                     raise HTTPError(404, reason=reason)
             else:
                 # Check if the file exists

--- a/qiita_pet/templates/admin_processing_job.html
+++ b/qiita_pet/templates/admin_processing_job.html
@@ -191,7 +191,7 @@
         $inp.attr('type', 'file');
       }
       else {
-        bootstrapAlert("Error: Parameter type (" + p_type + ") not recognized. Please, take a screenshot and <a href='mailto:qiita.help@gmail.com'>contact us</a>", "danger");
+        bootstrapAlert("Error: Parameter type (" + p_type + ") not recognized. Please, take a screenshot and <a href='mailto:{% raw qiita_config.portal_dir %}'>contact us</a>", "danger");
       }
     }
 

--- a/qiita_pet/templates/error.html
+++ b/qiita_pet/templates/error.html
@@ -3,7 +3,7 @@
     <h1 style="text-align:center">ERROR: CODE {{status_code}}!</h1>
     <h2 style="text-align:center">{% raw escape(error) %}</h2>
     <p style="text-align:center">The error has been logged and will be looked at.</p>
-    <p style="text-align:center">Need help? Send us an <a href="mailto:qiita.help@gmail.com">email</a>.</p>
+    <p style="text-align:center">Need help? Send us an <a href="mailto:{% raw qiita_config.help_email %}">email</a>.</p>
     {% if is_admin %}
     <p style="text-align:center">Go to the <a href="{% raw qiita_config.portal_dir %}/admin/error/">error page</a> to view the logs</p>
     {% end %}

--- a/qiita_pet/templates/list_analyses.html
+++ b/qiita_pet/templates/list_analyses.html
@@ -121,7 +121,7 @@
         message.append(' '+data[level]);
         // prepend the "Need help" message
         if (level == 'warning' || level == 'danger'){
-          message.append('<p style="text-align:center">Need help? Send us an <a href="mailto:qiita.help@gmail.com">email</a>.</p>');
+          message.append('<p style="text-align:center">Need help? Send us an <a href="mailto:{% raw qiita_config.portal_dir %}">email</a>.</p>');
         }
         analyses_all_messages.prepend(message);
       }

--- a/qiita_pet/templates/redbiom.html
+++ b/qiita_pet/templates/redbiom.html
@@ -163,7 +163,7 @@
     .fail(function(response, status, error) {
       var text = 'The query response is larger than is currently allowed, please try another. <a href="https://github.com/biocore/qiita/issues/2312" target="_blank">Track progress on this issue.</a>';
       if (response.status != 504) {
-        text = 'Status code: "' + response.status + '" - ' + error + '.<br/>Please send a screenshot to <a href="qiita.help@gmail.com">qiita.help@gmail.com</a>.';
+        text = 'Status code: "' + response.status + '" - ' + error + '.<br/>Please send a screenshot to <a href="mailto:{% raw qiita_config.portal_dir %}">{% raw qiita_config.portal_dir %}</a>.';
       }
       redbiom_info.html(
         `<div class="alert alert-danger alert-dismissible" role="alert">

--- a/qiita_pet/templates/sitebase.html
+++ b/qiita_pet/templates/sitebase.html
@@ -588,7 +588,7 @@
       <div id="footer" style="font-size: 12px; text-align: center; z-index: 1000;">
         Thank you for using Qiita. <a target="_blank" href="{% raw qiita_config.portal_dir %}/static/doc/html/faq.html#how-to-cite-qiita">Citing Qiita?</a>.
         <br/>
-        Questions? <a href="mailto:qiita.help@gmail.com">qiita.help@gmail.com</a>; don't forget to add your study or analysis id.
+        Questions? <a href="mailto:{% raw qiita_config.help_email %}">{% raw qiita_config.help_email %}</a>; don't forget to add your study or analysis id.
         <br/>
         Read our <a href="{% raw qiita_config.portal_dir %}/iframe/?iframe=qiita-terms">terms and conditions</a>.
       </div>

--- a/qiita_pet/templates/study_ajax/base_info.html
+++ b/qiita_pet/templates/study_ajax/base_info.html
@@ -159,7 +159,7 @@
         <input id="studyTags">
         <small>
           New tags are linked to the user that created them.
-          Report <a href="mailto:qiita.help@gmail.com">abuse</a>.
+          Report <a href="mailto:{% raw qiita_config.help_email %}">abuse</a>.
         </small>
         <br/>
         <button type="submit" class="btn btn-default" onclick="tags_patch(); return false;">Save tags</button>


### PR DESCRIPTION
Addresses issue #3375 
When we want to run multiple Qiita instances, it would make sense to use different email addresses a user can get help from. Therefore, I extended the configuration manager to parse two new strings for the help_email address and Jeff's sys-admin address.
Once you merge this PR, don't forget to update your configuration files!