### PR TITLE
Config statsmap lat long

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Deployed on January 8th, 2024
 * Workflow definitions can now use sample or preparation information columns/values to differentiate between them.
 * Updated the Adapter and host filtering plugin (qp-fastp-minimap2) to v2023.12 addressing a bug in adapter filtering; [more information](https://qiita.ucsd.edu/static/doc/html/processingdata/qp-fastp-minimap2.html).
 * Other fixes: [3334](https://github.com/qiita-spots/qiita/pull/3334), [3338](https://github.com/qiita-spots/qiita/pull/3338). Thank you @sjanssen2.
-* The internal Sequence Processing Pipeline is now using the human pan-genome reference, together with the GRCh38 genome + PhiX and CHM13 genome for human host filtering.
+* The internal Sequence Processing Pipeline is now using the human pan-genome reference, together with the GRCh38 genome + PhiX and T2T-CHM13v2.0 genome for human host filtering.
 
 
 Version 2023.10

--- a/qiita_core/configuration_manager.py
+++ b/qiita_core/configuration_manager.py
@@ -109,6 +109,12 @@ class ConfigurationManager(object):
         The portal subdirectory used in the URL
     portal_fp : str
         The filepath to the portal styling config file
+    stats_map_center_latitude : float
+        The center latitude of the world map, shown on the Stats map.
+        Defaults to 40.01027 (Boulder, CO, USA)
+    stats_map_center_longitude : float
+        The center longitude of the world map, shown on the Stats map.
+        Defaults to -105.24827 (Boulder, CO, USA)
     qiita_env : str
         The script used to start the qiita environment
     private_launcher : str
@@ -346,6 +352,41 @@ class ConfigurationManager(object):
                 self.portal_dir = self.portal_dir[:-1]
         else:
             self.portal_dir = ""
+
+        msg = ("The value %s for %s you set in Qiita's configuration file "
+               "(section 'portal') for the Stats world map cannot be "
+               "intepreted as a float! %s")
+        lat_default = 40.01027  # Boulder CO, USA
+        try:
+            self.stats_map_center_latitude = config.get(
+                'portal', 'STATS_MAP_CENTER_LATITUDE', fallback=lat_default)
+            if self.stats_map_center_latitude == '':
+                self.stats_map_center_latitude = lat_default
+            self.stats_map_center_latitude = float(
+                self.stats_map_center_latitude)
+        except ValueError as e:
+            raise ValueError(msg % (self.stats_map_center_latitude,
+                                    'STATS_MAP_CENTER_LATITUDE', e))
+
+        lon_default = -105.24827  # Boulder CO, USA
+        try:
+            self.stats_map_center_longitude = config.get(
+                'portal', 'STATS_MAP_CENTER_LONGITUDE', fallback=lon_default)
+            if self.stats_map_center_longitude == '':
+                self.stats_map_center_longitude = lon_default
+            self.stats_map_center_longitude = float(
+                self.stats_map_center_longitude)
+        except ValueError as e:
+            raise ValueError(msg % (self.stats_map_center_longitude,
+                                    'STATS_MAP_CENTER_LONGITUDE', e))
+        for (name, val) in [('latitude', self.stats_map_center_latitude),
+                            ('longitude', self.stats_map_center_longitude)]:
+            msg = ("The %s of %s you set in Qiita's configuration file "
+                   "(section 'portal') for the Stats world map cannot be %s!")
+            if val < -180:
+                raise ValueError(msg % (name, val, 'smaller than -180°'))
+            if val > 180:
+                raise ValueError(msg % (name, val, 'larger than 180°'))
 
     def _iframe(self, config):
         self.iframe_qiimp = config.get('iframe', 'QIIMP')

--- a/qiita_core/support_files/config_test.cfg
+++ b/qiita_core/support_files/config_test.cfg
@@ -183,6 +183,13 @@ PORTAL_DIR =
 # Full path to portal styling config file
 PORTAL_FP =
 
+# The center latitude of the world map, shown on the Stats map.
+# Defaults to 40.01027 (Boulder, CO, USA)
+STATS_MAP_CENTER_LATITUDE =
+
+# The center longitude of the world map, shown on the Stats map.
+# Defaults to -105.24827 (Boulder, CO, USA)
+STATS_MAP_CENTER_LONGITUDE =
 
 # ----------------------------- iframes settings ---------------------------
 [iframe]

--- a/qiita_core/tests/test_configuration_manager.py
+++ b/qiita_core/tests/test_configuration_manager.py
@@ -245,6 +245,50 @@ class ConfigurationManagerTests(TestCase):
         obs._get_portal(self.conf)
         self.assertEqual(obs.portal_dir, "/gold_portal")
 
+    def test_get_portal_latlong(self):
+        obs = ConfigurationManager()
+
+        # if parameters are given, but not set, they should default to Boulder
+        self.assertEqual(obs.stats_map_center_latitude, 40.01027)
+        self.assertEqual(obs.stats_map_center_longitude, -105.24827)
+
+        # a string cannot be parsed as a float
+        self.conf.set('portal', 'STATS_MAP_CENTER_LATITUDE', 'kurt')
+        with self.assertRaises(ValueError):
+            obs._get_portal(self.conf)
+
+        # check for illegal float values
+        self.conf.set('portal', 'STATS_MAP_CENTER_LATITUDE', "-200")
+        with self.assertRaises(ValueError):
+            obs._get_portal(self.conf)
+        self.conf.set('portal', 'STATS_MAP_CENTER_LATITUDE', "200")
+        with self.assertRaises(ValueError):
+            obs._get_portal(self.conf)
+
+        # check if value defaults if option is missing altogether
+        self.conf.remove_option('portal', 'STATS_MAP_CENTER_LATITUDE')
+        obs._get_portal(self.conf)
+        self.assertEqual(obs.stats_map_center_latitude, 40.01027)
+
+        # same as above, but for longitude
+        # a string cannot be parsed as a float
+        self.conf.set('portal', 'STATS_MAP_CENTER_LONGITUDE', 'kurt')
+        with self.assertRaises(ValueError):
+            obs._get_portal(self.conf)
+
+        # check for illegal float values
+        self.conf.set('portal', 'STATS_MAP_CENTER_LONGITUDE', "-200")
+        with self.assertRaises(ValueError):
+            obs._get_portal(self.conf)
+        self.conf.set('portal', 'STATS_MAP_CENTER_LONGITUDE', "200")
+        with self.assertRaises(ValueError):
+            obs._get_portal(self.conf)
+
+        # check if value defaults if option is missing altogether
+        self.conf.remove_option('portal', 'STATS_MAP_CENTER_LONGITUDE')
+        obs._get_portal(self.conf)
+        self.assertEqual(obs.stats_map_center_longitude, -105.24827)
+
 
 CONF = """
 # ------------------------------ Main settings --------------------------------
@@ -416,6 +460,14 @@ PORTAL_DIR = /portal
 
 # Full path to portal styling config file
 PORTAL_FP = /tmp/portal.cfg
+
+# The center latitude of the world map, shown on the Stats map.
+# Defaults to 40.01027 (Boulder, CO, USA)
+STATS_MAP_CENTER_LATITUDE =
+
+# The center longitude of the world map, shown on the Stats map.
+# Defaults to -105.24827 (Boulder, CO, USA)
+STATS_MAP_CENTER_LONGITUDE =
 
 # ----------------------------- iframes settings ---------------------------
 [iframe]

--- a/qiita_pet/templates/stats.html
+++ b/qiita_pet/templates/stats.html
@@ -81,7 +81,7 @@
         vectorLayer
       ],
       view: new ol.View({
-        center: ol.proj.fromLonLat([-105.24827, 40.01027]),
+        center: ol.proj.fromLonLat([{% raw qiita_config.stats_map_center_longitude %}, {% raw qiita_config.stats_map_center_latitude %}]),
         zoom: 4
       })
     });


### PR DESCRIPTION
It would be nice, if the Stats world map view could be centered by the user, e.g. I'd like to showcase European samples:
![image](https://github.com/qiita-spots/qiita/assets/11960616/baa7cc04-26fb-4878-ba6e-ebbf0bb48ef8)
Therefore, I suggest to have latitude and longitude as parameters in Qiita's configuration file. I thought the portal section might be appropriate, because different portals also might want to show different locations?
The defaults are Boulder, CO, i.e. if a user gives the parameters without values or skips these parameters altogether