### PR TITLE
change color of msg on profile page

### DIFF
--- a/qiita_pet/templates/user_profile.html
+++ b/qiita_pet/templates/user_profile.html
@@ -19,7 +19,7 @@ $( document ).ready(function() { dualpass_validator(); });
         {% raw form_item(class_='form-control') %}
       </div>
       {% end %}
-      <div style="color:red;">{{msg}}</div>
+      <div style="color:{% if msg.startswith('ERROR:') %}red{% else %}darkgreen{% end %};">{{msg}}</div>
       <button type="submit" class="btn btn-success">Save Edits</button>
     </form>
   </div>


### PR DESCRIPTION
When changing the user profile, the user gets feedback after he/she hits `Save Edits`. However, this msg is always red, even though it signals success, like here:
![image](https://github.com/qiita-spots/qiita/assets/11960616/6e83bd81-7ce0-41e3-a362-d3d30ceee4c2)

I suggest to use darkgreen by default:
![image](https://github.com/qiita-spots/qiita/assets/11960616/e9c3b98b-f8da-4ce4-9e77-0a1796f60695)
and only change to red (through jinja code in the template) when the msg starts with `ERROR:`

