### PR TITLE
fix sub-directory path

### DIFF
--- a/qiita_db/environment_manager.py
+++ b/qiita_db/environment_manager.py
@@ -145,7 +145,7 @@ def create_mountpoints():
                     if qiita_config.test_environment:
                         # if in test mode, we want to potentially fill the
                         # new directory with according test data
-                        copytree(get_support_file('test_data', subdir),
+                        copytree(get_support_file('test_data', mountpoint),
                                  join(qiita_config.base_data_dir, subdir))
                     else:
                         # in production mode, an empty directory is created


### PR DESCRIPTION
This is a follow up of #3462 

When I executed this code, I found that get_mount_point() returns complete paths, e.g. `/root/data/job` instead of "just" the sub-directory, i.e. `job`. Thus `get_support_file` returns the dst directory, instead of the src directory :-/